### PR TITLE
llcppsigfetch:abs include path & system header & config mode 's include flags

### DIFF
--- a/_xtool/llcppsigfetch/parse/cvt_test/cvt.go
+++ b/_xtool/llcppsigfetch/parse/cvt_test/cvt.go
@@ -79,7 +79,7 @@ func GetType(option *GetTypeOptions) (clang.Type, *clang.Index, *clang.Translati
 	}
 	cursor := unit.Cursor()
 	var typ clang.Type
-	parse.VisitChildren(cursor, func(child, parent clang.Cursor) clang.ChildVisitResult {
+	clangutils.VisitChildren(cursor, func(child, parent clang.Cursor) clang.ChildVisitResult {
 		if child.Kind == clang.CursorVarDecl && (option.ExpectTypeKind == clang.TypeInvalid || option.ExpectTypeKind == child.Type().Kind) {
 			typ = child.Type()
 			return clang.ChildVisit_Break

--- a/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/llgo.expect
@@ -1,4 +1,9 @@
 #stdout
+=== TestSystemHeader ===
+stdio.h is absolute path
+include files are all system headers
+=== TestInclusionMap ===
+sys/types.h include path found
 TestDefine Case 1:
 {
 	"temp.h":	{
@@ -110,10 +115,7 @@ TestInclude Case 1:
 	"temp.h":	{
 		"_Type":	"File",
 		"decls":	[],
-		"includes":	[{
-				"_Type":	"Include",
-				"Path":	"foo.h"
-			}],
+		"includes":	[],
 		"macros":	[]
 	}
 }
@@ -169,7 +171,7 @@ TestMacroExpansionOtherFile:
 			}],
 		"includes":	[{
 				"_Type":	"Include",
-				"Path":	"def.h"
+				"Path":	"./testdata/macroexpan/def.h"
 			}],
 		"macros":	[]
 	},

--- a/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/preprocess.go
+++ b/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/preprocess.go
@@ -1,14 +1,22 @@
 package main
 
 import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/goplus/llcppg/_xtool/llcppsigfetch/parse"
 	test "github.com/goplus/llcppg/_xtool/llcppsigfetch/parse/cvt_test"
 	"github.com/goplus/llcppg/_xtool/llcppsymg/clangutils"
+	"github.com/goplus/llcppg/ast"
 	"github.com/goplus/llgo/c"
 )
 
 func main() {
 	TestDefine()
 	TestInclude()
+	TestSystemHeader()
+	TestInclusionMap()
 	TestMacroExpansionOtherFile()
 }
 
@@ -27,6 +35,71 @@ func TestInclude() {
 		// `#include <limits.h>`, //  Standard libraries are mostly platform-dependent
 	}
 	test.RunTest("TestInclude", testCases)
+}
+
+func TestInclusionMap() {
+	fmt.Println("=== TestInclusionMap ===")
+	converter, err := parse.NewConverter(&clangutils.Config{
+		File:  "#include <sys/types.h>",
+		Temp:  true,
+		IsCpp: false,
+	})
+	if err != nil {
+		panic(err)
+	}
+	found := false
+	for _, f := range converter.Files {
+		if f.IncPath == "sys/types.h" {
+			found = true
+		}
+	}
+	if !found {
+		panic("sys/types.h not found")
+	} else {
+		fmt.Println("sys/types.h include path found")
+	}
+}
+
+func TestSystemHeader() {
+	fmt.Println("=== TestSystemHeader ===")
+	converter, err := parse.NewConverter(&clangutils.Config{
+		File:  "#include <stdio.h>",
+		Temp:  true,
+		IsCpp: false,
+	})
+	if err != nil {
+		panic(err)
+	}
+	converter.Convert()
+	if len(converter.Files) < 2 {
+		panic("expect 2 files")
+	}
+	if converter.Files[0].IsSys {
+		panic("entry file is not system header")
+	}
+
+	includePath := converter.Files[0].Doc.Includes[0].Path
+	if strings.HasSuffix(includePath, "stdio.h") && filepath.IsAbs(includePath) {
+		fmt.Println("stdio.h is absolute path")
+	}
+
+	for i := 1; i < len(converter.Files); i++ {
+		if !converter.Files[i].IsSys {
+			panic(fmt.Errorf("include file is not system header: %s", converter.Files[i].Path))
+		}
+		for _, decl := range converter.Files[i].Doc.Decls {
+			switch decl := decl.(type) {
+			case *ast.TypeDecl:
+			case *ast.EnumTypeDecl:
+			case *ast.FuncDecl:
+			case *ast.TypedefDecl:
+				if decl.DeclBase.Loc.File != converter.Files[i].Path {
+					fmt.Println("Decl is not in the file", decl.DeclBase.Loc.File, "expect", converter.Files[i].Path)
+				}
+			}
+		}
+	}
+	fmt.Println("include files are all system headers")
 }
 
 func TestMacroExpansionOtherFile() {

--- a/_xtool/llcppsigfetch/parse/dump.go
+++ b/_xtool/llcppsigfetch/parse/dump.go
@@ -1,9 +1,9 @@
 package parse
 
 import (
+	"github.com/goplus/llcppg/ast"
 	"github.com/goplus/llgo/c"
 	"github.com/goplus/llgo/c/cjson"
-	"github.com/goplus/llcppg/ast"
 )
 
 func MarshalOutputASTFiles(files []*FileEntry) *cjson.JSON {
@@ -11,8 +11,11 @@ func MarshalOutputASTFiles(files []*FileEntry) *cjson.JSON {
 	for _, entry := range files {
 		f := cjson.Object()
 		path := cjson.String(c.AllocaCStr(entry.Path))
+		incPath := cjson.String(c.AllocaCStr(entry.IncPath))
+		f.SetItem(c.Str("incPath"), incPath)
 		f.SetItem(c.Str("path"), path)
 		f.SetItem(c.Str("doc"), MarshalASTFile(entry.Doc))
+		f.SetItem(c.Str("isSys"), boolField(entry.IsSys))
 		root.AddItem(f)
 	}
 	return root

--- a/_xtool/llcppsymg/clangutils/clangutils.go
+++ b/_xtool/llcppsymg/clangutils/clangutils.go
@@ -18,6 +18,8 @@ type Config struct {
 
 type Visitor func(cursor, parent clang.Cursor) clang.ChildVisitResult
 
+type InclusionVisitor func(included_file clang.File, inclusions []clang.SourceLocation)
+
 const TEMP_FILE = "temp.h"
 
 func CreateTranslationUnit(config *Config) (*clang.Index, *clang.TranslationUnit, error) {
@@ -98,4 +100,12 @@ func VisitChildren(cursor clang.Cursor, fn Visitor) c.Uint {
 		cfn := *(*Visitor)(clientData)
 		return cfn(cursor, parent)
 	}, unsafe.Pointer(&fn))
+}
+
+func GetInclusions(unit *clang.TranslationUnit, visitor InclusionVisitor) {
+	clang.GetInclusions(unit, func(inced clang.File, incin *clang.SourceLocation, incilen c.Uint, data c.Pointer) {
+		ics := unsafe.Slice(incin, incilen)
+		cfn := *(*InclusionVisitor)(data)
+		cfn(inced, ics)
+	}, unsafe.Pointer(&visitor))
 }


### PR DESCRIPTION
* Change includes to output absolute paths for corresponding header files
* Identify system header files
* std include path
* config mode 's include flags
```json
    {
    "incPath": "stddef.h",
    "isSys": true,
    "path": "/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/stddef.h",
    "doc": {
      "_Type": "File",
      "includes": [
        {
          "_Type": "Include",
          "Path": "/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/_types.h"
        },
        {
          "_Type": "Include",
          "Path": "/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/_types/_size_t.h"
        },
      ],
    },
  {
    "incPath": "sys/_types/_size_t.h",
    "path": "/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/_types/_size_t.h",
    "doc": {
      "_Type": "File",
      "includes": [
        {
          "_Type": "Include",
          "Path": "/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/machine/_types.h"
        }
      ],
    },
    "isSys": true
  },
  },
```