### PR TITLE
ci:llgo cmptest for llcppsifetch & llcppsymg

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,6 +57,16 @@ jobs:
     - name: Install llcppg dependencies
       run: bash .github/workflows/install_llcppg_depend.sh
 
+    - name: Test llcppsymg
+      run: |
+        llgo cmptest ./_xtool/llcppsigfetch/parse/cvt_test/...
+
+        # llgo cmptest ./_xtool/llcppsymg/_cmptest/... causes 
+        # panic: runtime error: index out of range [0] with length 0
+        cd _xtool/llcppsymg/_cmptest
+        llgo cmptest ./...
+        cd ../../../
+
     - name: Test
       run: go test -v ./...
 


### PR DESCRIPTION
When executing llgo cmptest ./_xtool/llcppsymg/_cmptest/... from the project root directory, an unexpected panic occurs (see [goplus/llgo#895](https://github.com/goplus/llgo/issues/895)). However, the same test command works correctly when executed directly in the ./_xtool/llcppsymg/_cmptest/ directory.