### PR TITLE
llcppsigfetch:fix unexpect typedef decl when forward decl implement

### DIFF
--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/forwarddecl.go
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/forwarddecl.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	test "github.com/goplus/llcppg/_xtool/llcppsigfetch/parse/cvt_test"
+	"github.com/goplus/llcppg/_xtool/llcppsymg/clangutils"
+)
+
+func main() {
+	TestClassDecl()
+}
+
+func TestClassDecl() {
+	test.RunTestWithConfig(&clangutils.Config{
+		File:  "./hfile/forwarddecl.h",
+		Temp:  false,
+		IsCpp: false,
+	})
+}

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/hfile/forwarddecl.h
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/hfile/forwarddecl.h
@@ -1,0 +1,30 @@
+typedef struct sqlite3_pcache_page sqlite3_pcache_page;
+struct sqlite3_pcache_page
+{
+    void *pExtra;
+};
+
+typedef struct sqlite3_pcache sqlite3_pcache;
+
+typedef struct sqlite3_pcache_methods2 sqlite3_pcache_methods2;
+struct sqlite3_pcache_methods2
+{
+    int iVersion;
+    void (*xShutdown)(void *);
+    sqlite3_pcache *(*xCreate)(int szPage, int szExtra, int bPurgeable);
+};
+
+#define LUA_IDSIZE 60
+
+typedef struct lua_State lua_State;
+
+typedef struct lua_Debug lua_Debug;
+
+int(lua_getstack)(lua_State *L, int level, lua_Debug *ar);
+
+struct lua_Debug
+{
+    char short_src[LUA_IDSIZE];
+    /* private part */
+    struct CallInfo *i_ci; /* active function */
+};

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/hfile/forwarddecl.h
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/hfile/forwarddecl.h
@@ -1,3 +1,13 @@
+struct Foo
+{
+    struct bar *b;
+};
+typedef struct bar bar;
+struct bar
+{
+    int a;
+};
+
 typedef struct sqlite3_pcache_page sqlite3_pcache_page;
 struct sqlite3_pcache_page
 {
@@ -12,6 +22,18 @@ struct sqlite3_pcache_methods2
     int iVersion;
     void (*xShutdown)(void *);
     sqlite3_pcache *(*xCreate)(int szPage, int szExtra, int bPurgeable);
+};
+
+typedef struct sqlite3_file sqlite3_file;
+struct sqlite3_file
+{
+    const struct sqlite3_io_methods *pMethods; /* Methods for an open file */
+};
+
+typedef struct sqlite3_io_methods sqlite3_io_methods;
+struct sqlite3_io_methods
+{
+    int (*xUnfetch)(sqlite3_file *, int iOfst, void *p);
 };
 
 #define LUA_IDSIZE 60

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/llgo.expect
@@ -12,6 +12,84 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"Name":	"Foo"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"TagExpr",
+										"Name":	{
+											"_Type":	"Ident",
+											"Name":	"bar"
+										},
+										"Tag":	0
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	1,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"b"
+									}]
+							}]
+					},
+					"Methods":	[]
+				}
+			}, {
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"bar"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"BuiltinType",
+									"Kind":	6,
+									"Flags":	0
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	1,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"a"
+									}]
+							}]
+					},
+					"Methods":	[]
+				}
+			}, {
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
 					"Name":	"sqlite3_pcache_page"
 				},
 				"Type":	{
@@ -238,6 +316,152 @@
 								"Names":	[{
 										"_Type":	"Ident",
 										"Name":	"xCreate"
+									}]
+							}]
+					},
+					"Methods":	[]
+				}
+			}, {
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"sqlite3_file"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	null
+					},
+					"Methods":	[]
+				}
+			}, {
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"sqlite3_file"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"Ident",
+										"Name":	"sqlite3_io_methods"
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	1,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"pMethods"
+									}]
+							}]
+					},
+					"Methods":	[]
+				}
+			}, {
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"sqlite3_io_methods"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"FuncType",
+										"Params":	{
+											"_Type":	"FieldList",
+											"List":	[{
+													"_Type":	"Field",
+													"Type":	{
+														"_Type":	"PointerType",
+														"X":	{
+															"_Type":	"Ident",
+															"Name":	"sqlite3_file"
+														}
+													},
+													"Doc":	null,
+													"Comment":	null,
+													"IsStatic":	false,
+													"Access":	0,
+													"Names":	null
+												}, {
+													"_Type":	"Field",
+													"Type":	{
+														"_Type":	"BuiltinType",
+														"Kind":	6,
+														"Flags":	0
+													},
+													"Doc":	null,
+													"Comment":	null,
+													"IsStatic":	false,
+													"Access":	0,
+													"Names":	null
+												}, {
+													"_Type":	"Field",
+													"Type":	{
+														"_Type":	"PointerType",
+														"X":	{
+															"_Type":	"BuiltinType",
+															"Kind":	0,
+															"Flags":	0
+														}
+													},
+													"Doc":	null,
+													"Comment":	null,
+													"IsStatic":	false,
+													"Access":	0,
+													"Names":	null
+												}]
+										},
+										"Ret":	{
+											"_Type":	"BuiltinType",
+											"Kind":	6,
+											"Flags":	0
+										}
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	1,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"xUnfetch"
 									}]
 							}]
 					},

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/llgo.expect
@@ -1,0 +1,516 @@
+#stdout
+{
+	"./hfile/forwarddecl.h":	{
+		"_Type":	"File",
+		"decls":	[{
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"sqlite3_pcache_page"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	null
+					},
+					"Methods":	[]
+				}
+			}, {
+				"_Type":	"TypedefDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"sqlite3_pcache_page"
+				},
+				"Type":	{
+					"_Type":	"TagExpr",
+					"Name":	{
+						"_Type":	"Ident",
+						"Name":	"sqlite3_pcache_page"
+					},
+					"Tag":	0
+				}
+			}, {
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"sqlite3_pcache_page"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"BuiltinType",
+										"Kind":	0,
+										"Flags":	0
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	1,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"pExtra"
+									}]
+							}]
+					},
+					"Methods":	[]
+				}
+			}, {
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"sqlite3_pcache"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	null
+					},
+					"Methods":	[]
+				}
+			}, {
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"sqlite3_pcache_methods2"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	null
+					},
+					"Methods":	[]
+				}
+			}, {
+				"_Type":	"TypedefDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"sqlite3_pcache_methods2"
+				},
+				"Type":	{
+					"_Type":	"TagExpr",
+					"Name":	{
+						"_Type":	"Ident",
+						"Name":	"sqlite3_pcache_methods2"
+					},
+					"Tag":	0
+				}
+			}, {
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"sqlite3_pcache_methods2"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"BuiltinType",
+									"Kind":	6,
+									"Flags":	0
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	1,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"iVersion"
+									}]
+							}, {
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"FuncType",
+										"Params":	{
+											"_Type":	"FieldList",
+											"List":	[{
+													"_Type":	"Field",
+													"Type":	{
+														"_Type":	"PointerType",
+														"X":	{
+															"_Type":	"BuiltinType",
+															"Kind":	0,
+															"Flags":	0
+														}
+													},
+													"Doc":	null,
+													"Comment":	null,
+													"IsStatic":	false,
+													"Access":	0,
+													"Names":	null
+												}]
+										},
+										"Ret":	{
+											"_Type":	"BuiltinType",
+											"Kind":	0,
+											"Flags":	0
+										}
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	1,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"xShutdown"
+									}]
+							}, {
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"FuncType",
+										"Params":	{
+											"_Type":	"FieldList",
+											"List":	[{
+													"_Type":	"Field",
+													"Type":	{
+														"_Type":	"BuiltinType",
+														"Kind":	6,
+														"Flags":	0
+													},
+													"Doc":	null,
+													"Comment":	null,
+													"IsStatic":	false,
+													"Access":	0,
+													"Names":	null
+												}, {
+													"_Type":	"Field",
+													"Type":	{
+														"_Type":	"BuiltinType",
+														"Kind":	6,
+														"Flags":	0
+													},
+													"Doc":	null,
+													"Comment":	null,
+													"IsStatic":	false,
+													"Access":	0,
+													"Names":	null
+												}, {
+													"_Type":	"Field",
+													"Type":	{
+														"_Type":	"BuiltinType",
+														"Kind":	6,
+														"Flags":	0
+													},
+													"Doc":	null,
+													"Comment":	null,
+													"IsStatic":	false,
+													"Access":	0,
+													"Names":	null
+												}]
+										},
+										"Ret":	{
+											"_Type":	"PointerType",
+											"X":	{
+												"_Type":	"Ident",
+												"Name":	"sqlite3_pcache"
+											}
+										}
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	1,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"xCreate"
+									}]
+							}]
+					},
+					"Methods":	[]
+				}
+			}, {
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"lua_State"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	null
+					},
+					"Methods":	[]
+				}
+			}, {
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"lua_Debug"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	null
+					},
+					"Methods":	[]
+				}
+			}, {
+				"_Type":	"TypedefDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"lua_Debug"
+				},
+				"Type":	{
+					"_Type":	"TagExpr",
+					"Name":	{
+						"_Type":	"Ident",
+						"Name":	"lua_Debug"
+					},
+					"Tag":	0
+				}
+			}, {
+				"_Type":	"FuncDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"lua_getstack"
+				},
+				"MangledName":	"lua_getstack",
+				"Type":	{
+					"_Type":	"FuncType",
+					"Params":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"Ident",
+										"Name":	"lua_State"
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	0,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"L"
+									}]
+							}, {
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"BuiltinType",
+									"Kind":	6,
+									"Flags":	0
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	0,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"level"
+									}]
+							}, {
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"Ident",
+										"Name":	"lua_Debug"
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	0,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"ar"
+									}]
+							}]
+					},
+					"Ret":	{
+						"_Type":	"BuiltinType",
+						"Kind":	6,
+						"Flags":	0
+					}
+				},
+				"IsInline":	false,
+				"IsStatic":	false,
+				"IsConst":	false,
+				"IsExplicit":	false,
+				"IsConstructor":	false,
+				"IsDestructor":	false,
+				"IsVirtual":	false,
+				"IsOverride":	false
+			}, {
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/forwarddecl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"lua_Debug"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"ArrayType",
+									"Elt":	{
+										"_Type":	"BuiltinType",
+										"Kind":	2,
+										"Flags":	1
+									},
+									"Len":	{
+										"_Type":	"BasicLit",
+										"Kind":	0,
+										"Value":	"60"
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	1,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"short_src"
+									}]
+							}, {
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"TagExpr",
+										"Name":	{
+											"_Type":	"Ident",
+											"Name":	"CallInfo"
+										},
+										"Tag":	0
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	1,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"i_ci"
+									}]
+							}]
+					},
+					"Methods":	[]
+				}
+			}],
+		"includes":	[],
+		"macros":	[{
+				"_Type":	"Macro",
+				"Name":	"LUA_IDSIZE",
+				"Tokens":	[{
+						"_Type":	"Token",
+						"Token":	3,
+						"Lit":	"LUA_IDSIZE"
+					}, {
+						"_Type":	"Token",
+						"Token":	4,
+						"Lit":	"60"
+					}]
+			}]
+	}
+}
+
+
+#stderr
+
+#exit 0

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/llgo.expect
@@ -24,26 +24,6 @@
 					"Methods":	[]
 				}
 			}, {
-				"_Type":	"TypedefDecl",
-				"Loc":	{
-					"_Type":	"Location",
-					"File":	"./hfile/forwarddecl.h"
-				},
-				"Doc":	null,
-				"Parent":	null,
-				"Name":	{
-					"_Type":	"Ident",
-					"Name":	"sqlite3_pcache_page"
-				},
-				"Type":	{
-					"_Type":	"TagExpr",
-					"Name":	{
-						"_Type":	"Ident",
-						"Name":	"sqlite3_pcache_page"
-					},
-					"Tag":	0
-				}
-			}, {
 				"_Type":	"TypeDecl",
 				"Loc":	{
 					"_Type":	"Location",
@@ -123,26 +103,6 @@
 						"List":	null
 					},
 					"Methods":	[]
-				}
-			}, {
-				"_Type":	"TypedefDecl",
-				"Loc":	{
-					"_Type":	"Location",
-					"File":	"./hfile/forwarddecl.h"
-				},
-				"Doc":	null,
-				"Parent":	null,
-				"Name":	{
-					"_Type":	"Ident",
-					"Name":	"sqlite3_pcache_methods2"
-				},
-				"Type":	{
-					"_Type":	"TagExpr",
-					"Name":	{
-						"_Type":	"Ident",
-						"Name":	"sqlite3_pcache_methods2"
-					},
-					"Tag":	0
 				}
 			}, {
 				"_Type":	"TypeDecl",
@@ -324,26 +284,6 @@
 						"List":	null
 					},
 					"Methods":	[]
-				}
-			}, {
-				"_Type":	"TypedefDecl",
-				"Loc":	{
-					"_Type":	"Location",
-					"File":	"./hfile/forwarddecl.h"
-				},
-				"Doc":	null,
-				"Parent":	null,
-				"Name":	{
-					"_Type":	"Ident",
-					"Name":	"lua_Debug"
-				},
-				"Type":	{
-					"_Type":	"TagExpr",
-					"Name":	{
-						"_Type":	"Ident",
-						"Name":	"lua_Debug"
-					},
-					"Tag":	0
 				}
 			}, {
 				"_Type":	"FuncDecl",

--- a/cmd/gogensig/convert/package.go
+++ b/cmd/gogensig/convert/package.go
@@ -307,13 +307,6 @@ func (p *Package) NewTypedefDecl(typedefDecl *ast.TypedefDecl) error {
 		return err
 	}
 	p.CollectNameMapping(typedefDecl.Name.Name, name)
-	// todo(zzy): this block will be removed after https://github.com/goplus/llgo/pull/870
-	if obj := p.p.Types.Scope().Lookup(name); obj != nil {
-		// for a typedef ,always appear same name like
-		// typedef struct foo { int a; } foo;
-		// For this typedef, we only need skip this
-		return nil
-	}
 
 	genDecl := p.p.NewTypeDefs()
 	typ, err := p.ToType(typedefDecl.Type)


### PR DESCRIPTION
fix https://github.com/goplus/llcppg/issues/38

对于 "typedef struct xxx xxx;" 这样的声明，其 underlying type 的声明位置可能出现在两个地方：
1. 当结构体是内联定义时，底层类型声明位于 typedef 内部
2. 当源文件中存在独立的 struct xxx 实现时，底层类型声明位于实现的位置

因此，我们不应该使用声明位置来判断是否需要移除额外的 Typedef 节点，而是应该使用类型名称的比较来直接进行判断。