### PR TITLE
llcppg:cross file forward impl test case

### DIFF
--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/forwarddecl.go
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/forwarddecl.go
@@ -6,12 +6,21 @@ import (
 )
 
 func main() {
-	TestClassDecl()
+	TestForwardDecl()
+	TestForwardDeclCrossFile()
 }
 
-func TestClassDecl() {
+func TestForwardDecl() {
 	test.RunTestWithConfig(&clangutils.Config{
 		File:  "./hfile/forwarddecl.h",
+		Temp:  false,
+		IsCpp: false,
+	})
+}
+
+func TestForwardDeclCrossFile() {
+	test.RunTestWithConfig(&clangutils.Config{
+		File:  "./hfile/def.h",
 		Temp:  false,
 		IsCpp: false,
 	})

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/hfile/def.h
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/hfile/def.h
@@ -1,0 +1,3 @@
+#include "impl.h"
+typedef struct foo foo;
+void f(foo *f);

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/hfile/impl.h
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/hfile/impl.h
@@ -1,0 +1,4 @@
+struct foo
+{
+    int a;
+};

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/llgo.expect
@@ -674,6 +674,110 @@
 	}
 }
 
+{
+	"./hfile/def.h":	{
+		"_Type":	"File",
+		"decls":	[{
+				"_Type":	"FuncDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/def.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"f"
+				},
+				"MangledName":	"f",
+				"Type":	{
+					"_Type":	"FuncType",
+					"Params":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"Ident",
+										"Name":	"foo"
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	0,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"f"
+									}]
+							}]
+					},
+					"Ret":	{
+						"_Type":	"BuiltinType",
+						"Kind":	0,
+						"Flags":	0
+					}
+				},
+				"IsInline":	false,
+				"IsStatic":	false,
+				"IsConst":	false,
+				"IsExplicit":	false,
+				"IsConstructor":	false,
+				"IsDestructor":	false,
+				"IsVirtual":	false,
+				"IsOverride":	false
+			}],
+		"includes":	[{
+				"_Type":	"Include",
+				"Path":	"./hfile/impl.h"
+			}],
+		"macros":	[]
+	},
+	"./hfile/impl.h":	{
+		"_Type":	"File",
+		"decls":	[{
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/impl.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"foo"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"BuiltinType",
+									"Kind":	6,
+									"Flags":	0
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	1,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"a"
+									}]
+							}]
+					},
+					"Methods":	[]
+				}
+			}],
+		"includes":	[],
+		"macros":	[]
+	}
+}
+
 
 #stderr
 

--- a/cmd/gogensig/convert/_testdata/forwarddecl/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/gogensig.expect
@@ -1,3 +1,15 @@
+===== impl.go =====
+package forwarddecl
+
+import (
+	"github.com/goplus/llgo/c"
+	_ "unsafe"
+)
+
+type Foo struct {
+	A c.Long
+}
+
 ===== temp.go =====
 package forwarddecl
 
@@ -5,6 +17,10 @@ import (
 	"github.com/goplus/llgo/c"
 	"unsafe"
 )
+
+type Bar struct {
+	A *Foo
+}
 
 type File struct {
 	PMethods *IoMethods
@@ -69,6 +85,7 @@ type CallInfo struct {
 }
 
 ===== llcppg.pub =====
+bar Bar
 lua_Debug Debug
 lua_State State
 sqlite3_file File

--- a/cmd/gogensig/convert/_testdata/forwarddecl/hfile/impl.h
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/hfile/impl.h
@@ -1,0 +1,4 @@
+struct foo
+{
+    long a;
+};

--- a/cmd/gogensig/convert/_testdata/forwarddecl/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/hfile/temp.h
@@ -1,3 +1,11 @@
+#include "impl.h"
+typedef struct foo foo;
+struct bar
+{
+    foo *a;
+};
+
+
 typedef struct sqlite3_file sqlite3_file;
 struct sqlite3_file
 {


### PR DESCRIPTION
#48 

目前已会优先处理依赖的头文件中的类型声明实现，所以能正常转换类型实现