### PR TITLE
llcppsigfetch:support elaborate functype in funcdecl 

### DIFF
--- a/_xtool/llcppsigfetch/parse/cvt_test/decl_test/func_test/func.go
+++ b/_xtool/llcppsigfetch/parse/cvt_test/decl_test/func_test/func.go
@@ -1,6 +1,8 @@
 package main
 
-import test "github.com/goplus/llcppg/_xtool/llcppsigfetch/parse/cvt_test"
+import (
+	test "github.com/goplus/llcppg/_xtool/llcppsigfetch/parse/cvt_test"
+)
 
 func main() {
 	TestFuncDecl()
@@ -13,6 +15,13 @@ func TestFuncDecl() {
 		`void foo(int a,...);`,
 		`float* foo(int a,double b);`,
 		`static inline int add(int a, int b);`,
+		`typedef void (fntype)();
+		 fntype foo;
+		`,
+		`typedef long (fntype)(long a);
+		 typedef fntype fntype2;
+		 fntype2 foo;
+	   `,
 	}
 	test.RunTest("TestFuncDecl", testCases)
 }

--- a/_xtool/llcppsigfetch/parse/cvt_test/decl_test/func_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/decl_test/func_test/llgo.expect
@@ -317,6 +317,180 @@ TestFuncDecl Case 5:
 	}
 }
 
+TestFuncDecl Case 6:
+{
+	"temp.h":	{
+		"_Type":	"File",
+		"decls":	[{
+				"_Type":	"TypedefDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"fntype"
+				},
+				"Type":	{
+					"_Type":	"FuncType",
+					"Params":	{
+						"_Type":	"FieldList",
+						"List":	null
+					},
+					"Ret":	{
+						"_Type":	"BuiltinType",
+						"Kind":	0,
+						"Flags":	0
+					}
+				}
+			}, {
+				"_Type":	"FuncDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"foo"
+				},
+				"MangledName":	"_Z3foov",
+				"Type":	{
+					"_Type":	"FuncType",
+					"Params":	{
+						"_Type":	"FieldList",
+						"List":	null
+					},
+					"Ret":	{
+						"_Type":	"BuiltinType",
+						"Kind":	0,
+						"Flags":	0
+					}
+				},
+				"IsInline":	false,
+				"IsStatic":	false,
+				"IsConst":	false,
+				"IsExplicit":	false,
+				"IsConstructor":	false,
+				"IsDestructor":	false,
+				"IsVirtual":	false,
+				"IsOverride":	false
+			}],
+		"includes":	[],
+		"macros":	[]
+	}
+}
+
+TestFuncDecl Case 7:
+{
+	"temp.h":	{
+		"_Type":	"File",
+		"decls":	[{
+				"_Type":	"TypedefDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"fntype"
+				},
+				"Type":	{
+					"_Type":	"FuncType",
+					"Params":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"BuiltinType",
+									"Kind":	6,
+									"Flags":	4
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	0,
+								"Names":	null
+							}]
+					},
+					"Ret":	{
+						"_Type":	"BuiltinType",
+						"Kind":	6,
+						"Flags":	4
+					}
+				}
+			}, {
+				"_Type":	"TypedefDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"fntype2"
+				},
+				"Type":	{
+					"_Type":	"Ident",
+					"Name":	"fntype"
+				}
+			}, {
+				"_Type":	"FuncDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"foo"
+				},
+				"MangledName":	"_Z3fool",
+				"Type":	{
+					"_Type":	"FuncType",
+					"Params":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"BuiltinType",
+									"Kind":	6,
+									"Flags":	4
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	0,
+								"Names":	null
+							}]
+					},
+					"Ret":	{
+						"_Type":	"BuiltinType",
+						"Kind":	6,
+						"Flags":	4
+					}
+				},
+				"IsInline":	false,
+				"IsStatic":	false,
+				"IsConst":	false,
+				"IsExplicit":	false,
+				"IsConstructor":	false,
+				"IsDestructor":	false,
+				"IsVirtual":	false,
+				"IsOverride":	false
+			}],
+		"includes":	[],
+		"macros":	[]
+	}
+}
+
 
 #stderr
 

--- a/cmd/gogensig/convert/_testdata/funcrefer/conf/llcppg.symb.json
+++ b/cmd/gogensig/convert/_testdata/funcrefer/conf/llcppg.symb.json
@@ -1,8 +1,12 @@
 [
-    {
-      "mangle": "exec",
-      "c++": "exec",
-      "go": "Exec"
-    }
-  ]
-  
+  {
+    "mangle": "exec",
+    "c++": "exec",
+    "go": "Exec"
+  },
+  {
+    "mangle": "OSSL_provider_init2",
+    "c++": "OSSL_provider_init2",
+    "go": "ProviderInit2"
+  }
+]

--- a/cmd/gogensig/convert/_testdata/funcrefer/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/funcrefer/gogensig.expect
@@ -19,8 +19,13 @@ type Stream struct {
 	F  *c.FILE
 	Cb unsafe.Pointer
 }
+// llgo:type C
+type OSSLProviderInitFn func(__llgo_va_list ...interface{})
+//go:linkname ProviderInit2 C.OSSL_provider_init2
+func ProviderInit2(__llgo_va_list ...interface{})
 
 ===== llcppg.pub =====
 CallBack
 Hooks
+OSSL_provider_init_fn OSSLProviderInitFn
 Stream

--- a/cmd/gogensig/convert/_testdata/funcrefer/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/funcrefer/hfile/temp.h
@@ -13,3 +13,6 @@ typedef struct Stream {
   FILE *f; 
   CallBack cb; 
 } Stream;
+
+typedef void (OSSL_provider_init_fn)();
+extern OSSL_provider_init_fn OSSL_provider_init2;


### PR DESCRIPTION
fix #31 

支持函数声明使用已定义的函数类型