### PR TITLE
llcppsigfetch:recursive resolve typedefs to get underlying func type

### DIFF
--- a/_xtool/llcppsigfetch/parse/cvt_test/decl_test/func_test/func.go
+++ b/_xtool/llcppsigfetch/parse/cvt_test/decl_test/func_test/func.go
@@ -22,6 +22,15 @@ func TestFuncDecl() {
 		 typedef fntype fntype2;
 		 fntype2 foo;
 	   `,
+		`
+		typedef struct OSSL_CORE_HANDLE OSSL_CORE_HANDLE;
+		typedef struct OSSL_DISPATCH OSSL_DISPATCH;
+		typedef int (OSSL_provider_init_fn)(const OSSL_CORE_HANDLE *handle,
+		                                const OSSL_DISPATCH *in,
+		                                const OSSL_DISPATCH **out,
+		                                void **provctx);
+		OSSL_provider_init_fn OSSL_provider_init;
+		   `,
 	}
 	test.RunTest("TestFuncDecl", testCases)
 }

--- a/_xtool/llcppsigfetch/parse/cvt_test/decl_test/func_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/decl_test/func_test/llgo.expect
@@ -491,6 +491,241 @@ TestFuncDecl Case 7:
 	}
 }
 
+TestFuncDecl Case 8:
+{
+	"temp.h":	{
+		"_Type":	"File",
+		"decls":	[{
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"OSSL_CORE_HANDLE"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	null
+					},
+					"Methods":	[]
+				}
+			}, {
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"OSSL_DISPATCH"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	null
+					},
+					"Methods":	[]
+				}
+			}, {
+				"_Type":	"TypedefDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"OSSL_provider_init_fn"
+				},
+				"Type":	{
+					"_Type":	"FuncType",
+					"Params":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"Ident",
+										"Name":	"OSSL_CORE_HANDLE"
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	0,
+								"Names":	null
+							}, {
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"Ident",
+										"Name":	"OSSL_DISPATCH"
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	0,
+								"Names":	null
+							}, {
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"PointerType",
+										"X":	{
+											"_Type":	"Ident",
+											"Name":	"OSSL_DISPATCH"
+										}
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	0,
+								"Names":	null
+							}, {
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"PointerType",
+										"X":	{
+											"_Type":	"BuiltinType",
+											"Kind":	0,
+											"Flags":	0
+										}
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	0,
+								"Names":	null
+							}]
+					},
+					"Ret":	{
+						"_Type":	"BuiltinType",
+						"Kind":	6,
+						"Flags":	0
+					}
+				}
+			}, {
+				"_Type":	"FuncDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"OSSL_provider_init"
+				},
+				"MangledName":	"_Z18OSSL_provider_initPK16OSSL_CORE_HANDLEPK13OSSL_DISPATCHPS4_PPv",
+				"Type":	{
+					"_Type":	"FuncType",
+					"Params":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"Ident",
+										"Name":	"OSSL_CORE_HANDLE"
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	0,
+								"Names":	null
+							}, {
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"Ident",
+										"Name":	"OSSL_DISPATCH"
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	0,
+								"Names":	null
+							}, {
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"PointerType",
+										"X":	{
+											"_Type":	"Ident",
+											"Name":	"OSSL_DISPATCH"
+										}
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	0,
+								"Names":	null
+							}, {
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"PointerType",
+									"X":	{
+										"_Type":	"PointerType",
+										"X":	{
+											"_Type":	"BuiltinType",
+											"Kind":	0,
+											"Flags":	0
+										}
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	0,
+								"Names":	null
+							}]
+					},
+					"Ret":	{
+						"_Type":	"BuiltinType",
+						"Kind":	6,
+						"Flags":	0
+					}
+				},
+				"IsInline":	false,
+				"IsStatic":	false,
+				"IsConst":	false,
+				"IsExplicit":	false,
+				"IsConstructor":	false,
+				"IsDestructor":	false,
+				"IsVirtual":	false,
+				"IsOverride":	false
+			}],
+		"includes":	[],
+		"macros":	[]
+	}
+}
+
 
 #stderr
 

--- a/cmd/gogensig/convert/_testdata/funcrefer/conf/llcppg.symb.json
+++ b/cmd/gogensig/convert/_testdata/funcrefer/conf/llcppg.symb.json
@@ -8,5 +8,10 @@
     "mangle": "OSSL_provider_init2",
     "c++": "OSSL_provider_init2",
     "go": "ProviderInit2"
+  },
+  {
+    "mangle": "OSSL_provider_init",
+    "c++": "OSSL_provider_init",
+    "go": "ProviderInit"
   }
 ]

--- a/cmd/gogensig/convert/_testdata/funcrefer/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/funcrefer/gogensig.expect
@@ -24,8 +24,23 @@ type OSSLProviderInitFn func(__llgo_va_list ...interface{})
 //go:linkname ProviderInit2 C.OSSL_provider_init2
 func ProviderInit2(__llgo_va_list ...interface{})
 
+type OSSLCOREHANDLE struct {
+	Unused [8]uint8
+}
+
+type OSSLDISPATCH struct {
+	Unused [8]uint8
+}
+// llgo:type C
+type OSSLProviderInitFn2 func(*OSSLCOREHANDLE, *OSSLDISPATCH, **OSSLDISPATCH, *unsafe.Pointer) c.Int
+//go:linkname ProviderInit C.OSSL_provider_init
+func ProviderInit(*OSSLCOREHANDLE, *OSSLDISPATCH, **OSSLDISPATCH, *unsafe.Pointer) c.Int
+
 ===== llcppg.pub =====
 CallBack
 Hooks
+OSSL_CORE_HANDLE OSSLCOREHANDLE
+OSSL_DISPATCH OSSLDISPATCH
 OSSL_provider_init_fn OSSLProviderInitFn
+OSSL_provider_init_fn2 OSSLProviderInitFn2
 Stream

--- a/cmd/gogensig/convert/_testdata/funcrefer/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/funcrefer/hfile/temp.h
@@ -5,14 +5,24 @@ void exec(void *L, CallBack cb);
 
 typedef struct Hooks
 {
-      void *( *malloc_fn)(size_t sz);
-      void (*free_fn)(void *ptr);
-}Hooks;
+  void *(*malloc_fn)(size_t sz);
+  void (*free_fn)(void *ptr);
+} Hooks;
 
-typedef struct Stream {
-  FILE *f; 
-  CallBack cb; 
+typedef struct Stream
+{
+  FILE *f;
+  CallBack cb;
 } Stream;
 
-typedef void (OSSL_provider_init_fn)();
+typedef void(OSSL_provider_init_fn)();
 extern OSSL_provider_init_fn OSSL_provider_init2;
+
+typedef struct OSSL_CORE_HANDLE OSSL_CORE_HANDLE;
+typedef struct OSSL_DISPATCH OSSL_DISPATCH;
+typedef int(OSSL_provider_init_fn2)(const OSSL_CORE_HANDLE *handle,
+                                   const OSSL_DISPATCH *in,
+                                   const OSSL_DISPATCH **out,
+                                   void **provctx);
+
+OSSL_provider_init_fn2 OSSL_provider_init;


### PR DESCRIPTION
fix #51 

修改获取函数声明使用已定义的函数类型时获取underlying type的方案，原先的方案通过CanonicalType获取底层类型，会导致函数类型中的所有的typedef都被desugar，导致与原函数签名不一致。
##### detail
此前逻辑在获得实际函数定义时，使用了CanonicalType来获得实际typedef的函数类型，导致对于函数类型中，内部类型也做了CanonicalType的处理，从而导致获得类型时，获得的是比如 const OSSL_DISPATCH *in,实际定义的结构体类型，而不是一个类型引用，对此，获得函数的类型定义的底层类型应该通过其他方法来执行。
```
  visitTop: Cursor: OSSL_provider_init_fn
  ProcessTypeDefDecl: CursorName: OSSL_provider_init_fn CursorKind: TypedefDecl CursorTypeKind: Typedef
  ProcessUnderlyingType: not elaborated
   ProcessType: TypeName: int (const OSSL_CORE_HANDLE *, const OSSL_DISPATCH *, const OSSL_DISPATCH **, void **) TypeKind: FunctionProto
   ProcessType: FunctionType  TypeName: int (const OSSL_CORE_HANDLE *, const OSSL_DISPATCH *, const OSSL_DISPATCH **, void **) TypeKind: FunctionProto
    ProcessFunctionType: TypeName: int (const OSSL_CORE_HANDLE *, const OSSL_DISPATCH *, const OSSL_DISPATCH **, void **) TypeKind: FunctionProto
    ProcessFunctionType: ResultType TypeName: int TypeKind: Int
     ProcessType: TypeName: int TypeKind: Int
      ProcessBuiltinType: TypeName: int TypeKind: Int
     ProcessType: TypeName: const OSSL_CORE_HANDLE * TypeKind: Pointer
     ProcessType: PointerType  Pointee TypeName: const OSSL_CORE_HANDLE TypeKind: Elaborated
      ProcessType: TypeName: const OSSL_CORE_HANDLE TypeKind: Elaborated
       ProcessElaboratedType: TypeName: const OSSL_CORE_HANDLE TypeKind: Elaborated
     ProcessType: TypeName: const OSSL_DISPATCH * TypeKind: Pointer
     ProcessType: PointerType  Pointee TypeName: const OSSL_DISPATCH TypeKind: Elaborated
      ProcessType: TypeName: const OSSL_DISPATCH TypeKind: Elaborated
       ProcessElaboratedType: TypeName: const OSSL_DISPATCH TypeKind: Elaborated
     ProcessType: TypeName: const OSSL_DISPATCH ** TypeKind: Pointer
     ProcessType: PointerType  Pointee TypeName: const OSSL_DISPATCH * TypeKind: Pointer
      ProcessType: TypeName: const OSSL_DISPATCH * TypeKind: Pointer
      ProcessType: PointerType  Pointee TypeName: const OSSL_DISPATCH TypeKind: Elaborated
       ProcessType: TypeName: const OSSL_DISPATCH TypeKind: Elaborated
        ProcessElaboratedType: TypeName: const OSSL_DISPATCH TypeKind: Elaborated
     ProcessType: TypeName: void ** TypeKind: Pointer
     ProcessType: PointerType  Pointee TypeName: void * TypeKind: Pointer
      ProcessType: TypeName: void * TypeKind: Pointer
      ProcessType: PointerType  Pointee TypeName: void TypeKind: Void
       ProcessType: TypeName: void TypeKind: Void
        ProcessBuiltinType: TypeName: void TypeKind: Void
 visitTop: ProcessTypeDefDecl END OSSL_provider_init_fn
 GetCurFile: found /opt/homebrew/Cellar/openssl@3/3.4.0/include/openssl/core.h
 visitTop: Cursor: OSSL_provider_init
  ProcessFuncDecl: CursorName: OSSL_provider_init CursorKind: FunctionDecl
  ProcessFuncDecl: TypeName: OSSL_provider_init_fn TypeKind: Elaborated
  ProcessFuncDecl: CanonicalType TypeName: int (const struct ossl_core_handle_st *, const struct ossl_dispatch_st *, const struct ossl_dispatch_st **, void **) TypeKind: FunctionProto
   ProcessType: TypeName: int (const struct ossl_core_handle_st *, const struct ossl_dispatch_st *, const struct ossl_dispatch_st **, void **) TypeKind: FunctionProto
   ProcessType: FunctionType  TypeName: int (const struct ossl_core_handle_st *, const struct ossl_dispatch_st *, const struct ossl_dispatch_st **, void **) TypeKind: FunctionProto
    ProcessFunctionType: TypeName: int (const struct ossl_core_handle_st *, const struct ossl_dispatch_st *, const struct ossl_dispatch_st **, void **) TypeKind: FunctionProto
    ProcessFunctionType: ResultType TypeName: int TypeKind: Int
     ProcessType: TypeName: int TypeKind: Int
      ProcessBuiltinType: TypeName: int TypeKind: Int
     ProcessType: TypeName: const struct ossl_core_handle_st * TypeKind: Pointer
     ProcessType: PointerType  Pointee TypeName: const struct ossl_core_handle_st TypeKind: Record
      ProcessType: TypeName: const struct ossl_core_handle_st TypeKind: Record
      ProcessType: Unknown Type TypeName: const struct ossl_core_handle_st TypeKind: Record
     ProcessType: TypeName: const struct ossl_dispatch_st * TypeKind: Pointer
     ProcessType: PointerType  Pointee TypeName: const struct ossl_dispatch_st TypeKind: Record
      ProcessType: TypeName: const struct ossl_dispatch_st TypeKind: Record
      ProcessType: Unknown Type TypeName: const struct ossl_dispatch_st TypeKind: Record
     ProcessType: TypeName: const struct ossl_dispatch_st ** TypeKind: Pointer
     ProcessType: PointerType  Pointee TypeName: const struct ossl_dispatch_st * TypeKind: Pointer
      ProcessType: TypeName: const struct ossl_dispatch_st * TypeKind: Pointer
      ProcessType: PointerType  Pointee TypeName: const struct ossl_dispatch_st TypeKind: Record
       ProcessType: TypeName: const struct ossl_dispatch_st TypeKind: Record
       ProcessType: Unknown Type TypeName: const struct ossl_dispatch_st TypeKind: Record
     ProcessType: TypeName: void ** TypeKind: Pointer
     ProcessType: PointerType  Pointee TypeName: void * TypeKind: Pointer
      ProcessType: TypeName: void * TypeKind: Pointer
      ProcessType: PointerType  Pointee TypeName: void TypeKind: Void
       ProcessType: TypeName: void TypeKind: Void
        ProcessBuiltinType: TypeName: void TypeKind: Void
  ProcessFuncDecl: ProcessFieldList
 visitTop: ProcessFuncDecl END OSSL_provider_init OSSL_provider_init isStatic: false isInline: false
```
