### PR TITLE
gogensig:defer init typedef a incomplete type

### DIFF
--- a/cmd/gogensig/convert/_testdata/funcrefer/conf/llcppg.symb.json
+++ b/cmd/gogensig/convert/_testdata/funcrefer/conf/llcppg.symb.json
@@ -13,5 +13,10 @@
     "mangle": "OSSL_provider_init",
     "c++": "OSSL_provider_init",
     "go": "ProviderInit"
+  },
+  {
+    "mangle": "OSSL_PROVIDER_add_builtin",
+    "c++": "OSSL_PROVIDER_add_builtin",
+    "go": "ProviderAddBuiltin"
   }
 ]

--- a/cmd/gogensig/convert/_testdata/funcrefer/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/funcrefer/gogensig.expect
@@ -36,11 +36,20 @@ type OSSLProviderInitFn2 func(*OSSLCOREHANDLE, *OSSLDISPATCH, **OSSLDISPATCH, *u
 //go:linkname ProviderInit C.OSSL_provider_init
 func ProviderInit(*OSSLCOREHANDLE, *OSSLDISPATCH, **OSSLDISPATCH, *unsafe.Pointer) c.Int
 
+type OsslLibCtxSt struct {
+	Unused [8]uint8
+}
+type OSSLLIBCTX OsslLibCtxSt
+//go:linkname ProviderAddBuiltin C.OSSL_PROVIDER_add_builtin
+func ProviderAddBuiltin(*OSSLLIBCTX, name *int8, init_fn *OSSLProviderInitFn2) c.Int
+
 ===== llcppg.pub =====
 CallBack
 Hooks
 OSSL_CORE_HANDLE OSSLCOREHANDLE
 OSSL_DISPATCH OSSLDISPATCH
+OSSL_LIB_CTX OSSLLIBCTX
 OSSL_provider_init_fn OSSLProviderInitFn
 OSSL_provider_init_fn2 OSSLProviderInitFn2
 Stream
+ossl_lib_ctx_st OsslLibCtxSt

--- a/cmd/gogensig/convert/_testdata/funcrefer/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/funcrefer/hfile/temp.h
@@ -26,3 +26,9 @@ typedef int(OSSL_provider_init_fn2)(const OSSL_CORE_HANDLE *handle,
                                    void **provctx);
 
 OSSL_provider_init_fn2 OSSL_provider_init;
+
+typedef struct ossl_lib_ctx_st OSSL_LIB_CTX;
+
+int OSSL_PROVIDER_add_builtin(OSSL_LIB_CTX *, const char *name,
+                              OSSL_provider_init_fn2 *init_fn);
+

--- a/cmd/gogensig/convert/convert_test.go
+++ b/cmd/gogensig/convert/convert_test.go
@@ -386,7 +386,6 @@ import (
 )
 
 type NormalType c.Int
-
 type Foo struct {
 	Unused [8]uint8
 }

--- a/cmd/gogensig/convert/package_bulitin_test.go
+++ b/cmd/gogensig/convert/package_bulitin_test.go
@@ -1,0 +1,56 @@
+package convert
+
+import (
+	"testing"
+
+	"github.com/goplus/gogen"
+	"github.com/goplus/llcppg/ast"
+	cfg "github.com/goplus/llcppg/cmd/gogensig/config"
+	cppgtypes "github.com/goplus/llcppg/types"
+)
+
+func TestTypeRefIncompleteFail(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Expected panic, got nil")
+		}
+	}()
+	pkg := NewPackage(&PackageConfig{
+		PkgBase: PkgBase{
+			PkgPath:  ".",
+			CppgConf: &cppgtypes.Config{},
+			Pubs:     make(map[string]string),
+		},
+		Name:        "testpkg",
+		GenConf:     &gogen.Config{},
+		OutputDir:   "",
+		SymbolTable: cfg.CreateSymbolTable([]cfg.SymbolEntry{}),
+	})
+	pkg.cvt.SysTypeLoc["Bar"] = &HeaderInfo{
+		IncPath: "Bar",
+		Path:    "Bar",
+	}
+	pkg.incomplete["Bar"] = &gogen.TypeDecl{}
+	err := pkg.NewTypedefDecl(&ast.TypedefDecl{
+		Name: &ast.Ident{Name: "Foo"},
+		Type: &ast.TagExpr{
+			Name: &ast.Ident{Name: "Bar"},
+		},
+	})
+	if err != nil {
+		t.Fatal("NewTypedefDecl failed:", err)
+	}
+	delete(pkg.incomplete, "Bar")
+
+	_, err = pkg.WriteToBuffer("testpkg")
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	pkg.handleTyperefIncomplete(&ast.TagExpr{
+		Tag: 0,
+		Name: &ast.ScopingExpr{
+			X: &ast.Ident{Name: "Bar"},
+		},
+	}, nil)
+}


### PR DESCRIPTION
fix #46 
type 创建一个新类型时，其underlying必须存在，所以当typedef一个未完成类型时，其underlying不存在，对该情况则延迟加载该类型的初始化