### PR TITLE
gogensig:remove extra pointer when ref defined functype (not func pointer) as param

### DIFF
--- a/cmd/gogensig/convert/_testdata/funcrefer/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/funcrefer/gogensig.expect
@@ -41,7 +41,7 @@ type OsslLibCtxSt struct {
 }
 type OSSLLIBCTX OsslLibCtxSt
 //go:linkname ProviderAddBuiltin C.OSSL_PROVIDER_add_builtin
-func ProviderAddBuiltin(*OSSLLIBCTX, name *int8, init_fn *OSSLProviderInitFn2) c.Int
+func ProviderAddBuiltin(*OSSLLIBCTX, name *int8, init_fn OSSLProviderInitFn2) c.Int
 
 ===== llcppg.pub =====
 CallBack

--- a/cmd/gogensig/convert/type.go
+++ b/cmd/gogensig/convert/type.go
@@ -129,12 +129,22 @@ func (p *TypeConv) handlePointerType(t *ast.PointerType) (types.Type, error) {
 	if p.typeMap.IsVoidType(baseType) {
 		return p.typeMap.CType("Pointer"), nil
 	}
+
+	if p.ctx == Param {
+		if named, ok := baseType.(*types.Named); ok {
+			if _, ok := named.Underlying().(*types.Signature); ok {
+				return baseType, nil
+			}
+		}
+	}
+
 	if baseFuncType, ok := baseType.(*types.Signature); ok {
 		if p.ctx == Record {
 			return p.typeMap.CType("Pointer"), nil
 		}
 		return baseFuncType, nil
 	}
+
 	return types.NewPointer(baseType), nil
 }
 


### PR DESCRIPTION
fix #50 