### PR TITLE
gogensig:fix unexpect object redeined

### DIFF
--- a/cmd/gogensig/convert/_testdata/forwarddecl/conf/llcppg.symb.json
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/conf/llcppg.symb.json
@@ -1,8 +1,12 @@
 [
-    {
-      "mangle": "lua_getstack",
-      "c++": "lua_getstack",
-      "go": "Getstack"
-    }
-  ]
-  
+  {
+    "mangle": "lua_getstack",
+    "c++": "lua_getstack",
+    "go": "Getstack"
+  },
+  {
+    "mangle": "fts5_extension_function",
+    "c++": "fts5_extension_function",
+    "go": "Fts5ExtensionFunction"
+  }
+]

--- a/cmd/gogensig/convert/_testdata/forwarddecl/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/gogensig.expect
@@ -84,12 +84,41 @@ type CallInfo struct {
 	Unused [8]uint8
 }
 
+type Fts5ExtensionApi struct {
+	Unused [8]uint8
+}
+
+type Fts5Context struct {
+	Unused [8]uint8
+}
+
+type Fts5PhraseIter struct {
+	A *int8
+	B *int8
+}
+
+type Value struct {
+	Unused [8]uint8
+}
+
+type Context struct {
+	Unused [8]uint8
+}
+// llgo:type C
+type Fts5ExtensionFunction func(*Fts5ExtensionApi, *Fts5Context, *Context, c.Int, **Value)
+
 ===== llcppg.pub =====
+Fts5Context
+Fts5ExtensionApi
+Fts5PhraseIter
 bar Bar
+fts5_extension_function Fts5ExtensionFunction
 lua_Debug Debug
 lua_State State
+sqlite3_context Context
 sqlite3_file File
 sqlite3_io_methods IoMethods
 sqlite3_pcache Pcache
 sqlite3_pcache_methods2 PcacheMethods2
 sqlite3_pcache_page PcachePage
+sqlite3_value Value

--- a/cmd/gogensig/convert/_testdata/forwarddecl/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/hfile/temp.h
@@ -5,7 +5,6 @@ struct bar
     foo *a;
 };
 
-
 typedef struct sqlite3_file sqlite3_file;
 struct sqlite3_file
 {
@@ -72,4 +71,23 @@ struct lua_Debug
     char short_src[LUA_IDSIZE];
     /* private part */
     struct CallInfo *i_ci; /* active function */
+};
+
+typedef struct Fts5ExtensionApi Fts5ExtensionApi;
+typedef struct Fts5Context Fts5Context;
+typedef struct Fts5PhraseIter Fts5PhraseIter;
+
+typedef struct sqlite3_value sqlite3_value;
+typedef struct sqlite3_context sqlite3_context;
+typedef void (*fts5_extension_function)(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
+                                        Fts5Context *pFts,            /* First arg to pass to pApi functions */
+                                        sqlite3_context *pCtx,        /* Context for returning result/error */
+                                        int nVal,                     /* Number of values in apVal[] array */
+                                        sqlite3_value **apVal         /* Array of trailing arguments */
+);
+
+struct Fts5PhraseIter
+{
+    const unsigned char *a;
+    const unsigned char *b;
 };

--- a/cmd/gogensig/convert/package.go
+++ b/cmd/gogensig/convert/package.go
@@ -553,18 +553,19 @@ func (p *Package) DeclName(name string) (pubName string, changed bool, err error
 
 // For a decl name, if it's a current package, remove the prefixed name
 func (p *Package) GetGoName(name string) (pubName string, changed bool) {
-	prefixes := []string{}
+	if goName, exists := p.Pubs[name]; exists {
+		if goName == "" {
+			return name, false
+		}
+		return goName, goName != name
+	}
+	var prefixes []string
 	if p.curFile.inCurPkg {
 		prefixes = p.CppgConf.TrimPrefixes
 	}
-	goName, ok := p.Pubs[name]
-	if ok {
-		pubName = goName
-	} else {
-		pubName = names.GoName(name, prefixes)
-	}
-	changed = pubName != name
-	return
+
+	pubName = names.GoName(name, prefixes)
+	return pubName, pubName != name
 }
 
 func (p *Package) CollectNameMapping(originName, newName string) {


### PR DESCRIPTION
fix #58 

之前的逻辑对于pubname和cname一致的情况下，会错误的使用空值作为新的pubname，导致不应该被提交的名称被提交了