### PR TITLE
gogensig:fix unexpect redefined forward decl 's fail output

### DIFF
--- a/cmd/gogensig/convert/_testdata/forwarddecl/conf/llcppg.cfg
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/conf/llcppg.cfg
@@ -1,6 +1,6 @@
 {
   "name": "forwarddecl",
-  "include": ["temp.h"],
+  "include": ["temp.h", "impl.h"],
   "trimPrefixes": ["sqlite3_","lua_"],
   "cplusplus":false
 }

--- a/cmd/gogensig/convert/_testdata/forwarddecl/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/gogensig.expect
@@ -10,6 +10,10 @@ type Foo struct {
 	A c.Long
 }
 
+type File struct {
+	Unused [8]uint8
+}
+
 ===== temp.go =====
 package forwarddecl
 
@@ -20,10 +24,6 @@ import (
 
 type Bar struct {
 	A *Foo
-}
-
-type File struct {
-	PMethods *IoMethods
 }
 
 type IoMethods struct {
@@ -112,6 +112,7 @@ Fts5Context
 Fts5ExtensionApi
 Fts5PhraseIter
 bar Bar
+foo Foo
 fts5_extension_function Fts5ExtensionFunction
 lua_Debug Debug
 lua_State State

--- a/cmd/gogensig/convert/_testdata/forwarddecl/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/gogensig.expect
@@ -11,7 +11,7 @@ type Foo struct {
 }
 
 type File struct {
-	Unused [8]uint8
+	PMethods *IoMethods
 }
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/forwarddecl/hfile/impl.h
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/hfile/impl.h
@@ -1,4 +1,7 @@
-struct foo
-{
+struct foo {
     long a;
 };
+
+// Forward declaration of sqlite3_file
+// todo: the sqlite3_file 's real type should be defined.
+struct sqlite3_file;

--- a/cmd/gogensig/convert/_testdata/forwarddecl/hfile/impl.h
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/hfile/impl.h
@@ -3,5 +3,4 @@ struct foo {
 };
 
 // Forward declaration of sqlite3_file
-// todo: the sqlite3_file 's real type should be defined.
 struct sqlite3_file;

--- a/cmd/gogensig/convert/_testdata/forwarddecl/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/hfile/temp.h
@@ -1,25 +1,21 @@
 #include "impl.h"
 typedef struct foo foo;
-struct bar
-{
+struct bar {
     foo *a;
 };
 
 typedef struct sqlite3_file sqlite3_file;
-struct sqlite3_file
-{
+struct sqlite3_file {
     const struct sqlite3_io_methods *pMethods; /* Methods for an open file */
 };
 
 typedef struct sqlite3_io_methods sqlite3_io_methods;
-struct sqlite3_io_methods
-{
+struct sqlite3_io_methods {
     int (*xUnfetch)(sqlite3_file *, int iOfst, void *p);
 };
 
 typedef struct sqlite3_pcache_page sqlite3_pcache_page;
-struct sqlite3_pcache_page
-{
+struct sqlite3_pcache_page {
     void *pBuf;
     void *pExtra;
 };
@@ -27,8 +23,7 @@ struct sqlite3_pcache_page
 typedef struct sqlite3_pcache sqlite3_pcache;
 
 typedef struct sqlite3_pcache_methods2 sqlite3_pcache_methods2;
-struct sqlite3_pcache_methods2
-{
+struct sqlite3_pcache_methods2 {
     int iVersion;
     void *pArg;
     int (*xInit)(void *);
@@ -52,8 +47,7 @@ typedef struct lua_Debug lua_Debug;
 
 int(lua_getstack)(lua_State *L, int level, lua_Debug *ar);
 
-struct lua_Debug
-{
+struct lua_Debug {
     int event;
     const char *name;
     const char *namewhat;
@@ -86,8 +80,7 @@ typedef void (*fts5_extension_function)(const Fts5ExtensionApi *pApi, /* API off
                                         sqlite3_value **apVal         /* Array of trailing arguments */
 );
 
-struct Fts5PhraseIter
-{
+struct Fts5PhraseIter {
     const unsigned char *a;
     const unsigned char *b;
 };

--- a/cmd/gogensig/convert/basic/basic.go
+++ b/cmd/gogensig/convert/basic/basic.go
@@ -40,6 +40,7 @@ func ConvertProcesser(cfg *Config) (*processor.DocFileSetProcessor, *convert.Pac
 		},
 		DepIncs: incs,
 		Done: func() {
+			astConvert.WritePkgFiles()
 			astConvert.WriteLinkFile()
 			astConvert.WritePubFile()
 		},

--- a/cmd/gogensig/convert/convert.go
+++ b/cmd/gogensig/convert/convert.go
@@ -150,7 +150,12 @@ func (p *AstConvert) VisitStart(path string, incPath string, isSys bool) {
 func (p *AstConvert) VisitDone(incPath string) {
 	if p.visitDone != nil {
 		p.visitDone(p.Pkg, incPath)
-	} else {
-		p.Pkg.Write(incPath)
+	}
+}
+
+func (p *AstConvert) WritePkgFiles() {
+	err := p.Pkg.WritePkgFiles()
+	if err != nil {
+		log.Panicf("WritePkgFiles: %v", err)
 	}
 }

--- a/cmd/gogensig/convert/package.go
+++ b/cmd/gogensig/convert/package.go
@@ -38,6 +38,7 @@ type Package struct {
 	conf    *PackageConfig // package config
 	cvt     *TypeConv      // package type convert
 	curFile *HeaderFile    // current processing c header file.
+	files   []*HeaderFile  // header files.
 
 	// incomplete stores type declarations that are not fully defined yet.
 	// This is used to handle forward declarations and self-referential types in C/C++.

--- a/cmd/gogensig/convert/package.go
+++ b/cmd/gogensig/convert/package.go
@@ -256,8 +256,12 @@ func (p *Package) NewTypeDecl(typeDecl *ast.TypeDecl) error {
 	}
 
 	cname := typeDecl.Name.Name
+	isForward := p.cvt.inComplete(typeDecl.Type)
 	name, changed, err := p.DeclName(cname)
 	if err != nil {
+		if isForward {
+			return nil
+		}
 		return err
 	}
 	p.CollectNameMapping(cname, name)
@@ -268,7 +272,7 @@ func (p *Package) NewTypeDecl(typeDecl *ast.TypeDecl) error {
 		substObj(p.p.Types, p.p.Types.Scope(), cname, decl.Type().Obj())
 	}
 
-	if !p.cvt.inComplete(typeDecl.Type) {
+	if !isForward {
 		if err := p.handleCompleteType(decl, typeDecl.Type, cname); err != nil {
 			return err
 		}

--- a/cmd/gogensig/convert/package.go
+++ b/cmd/gogensig/convert/package.go
@@ -508,9 +508,6 @@ func (p *Package) WritePkgFiles() error {
 //
 // Files that are already processed in dependent packages will not be output.
 func (p *Package) Write(headerFile string) error {
-	if p.curFile.isSys {
-		return nil
-	}
 	fileName := names.HeaderFileToGo(headerFile)
 	filePath := filepath.Join(p.GetOutputDir(), fileName)
 	if debug {

--- a/cmd/gogensig/convert/package_bulitin_test.go
+++ b/cmd/gogensig/convert/package_bulitin_test.go
@@ -42,7 +42,7 @@ func TestTypeRefIncompleteFail(t *testing.T) {
 	}
 	delete(pkg.incomplete, "Bar")
 
-	_, err = pkg.WriteToBuffer("testpkg")
+	err = pkg.WritePkgFiles()
 	if err == nil {
 		t.Fatal("Expected error, got nil")
 	}

--- a/cmd/gogensig/convert/package_test.go
+++ b/cmd/gogensig/convert/package_test.go
@@ -1588,17 +1588,17 @@ func TestForwardDecl(t *testing.T) {
 		),
 	})
 
-	// forward decl
-	err := pkg.NewTypeDecl(&ast.TypeDecl{
+	forwardDecl := &ast.TypeDecl{
 		Name: &ast.Ident{Name: "Foo"},
 		Type: &ast.RecordType{
 			Tag:    ast.Struct,
 			Fields: &ast.FieldList{},
 		},
-	})
-
+	}
+	// forward decl
+	err := pkg.NewTypeDecl(forwardDecl)
 	if err != nil {
-		t.Fatalf("NewTypeDecl failed: %v", err)
+		t.Fatalf("Forward decl failed: %v", err)
 	}
 
 	// complete decl
@@ -1616,6 +1616,12 @@ func TestForwardDecl(t *testing.T) {
 			},
 		},
 	})
+
+	if err != nil {
+		t.Fatalf("NewTypeDecl failed: %v", err)
+	}
+
+	err = pkg.NewTypeDecl(forwardDecl)
 
 	if err != nil {
 		t.Fatalf("NewTypeDecl failed: %v", err)

--- a/cmd/gogensig/convert/package_test.go
+++ b/cmd/gogensig/convert/package_test.go
@@ -307,30 +307,9 @@ func TestPackageWrite(t *testing.T) {
 		}
 	})
 
-	t.Run("UnwritableOutputDir", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp(dir, "test_package_write_unwritable")
-		if err != nil {
-			t.Fatalf("Failed to create temporary directory: %v", err)
-		}
-		defer os.RemoveAll(tempDir)
-
-		pkg := createTestPkg(t, &convert.PackageConfig{
-			OutputDir: tempDir,
-		})
-
-		// read-only
-		err = os.Chmod(tempDir, 0555)
-		defer func() {
-			if err := os.Chmod(tempDir, 0755); err != nil {
-				t.Fatalf("Failed to change directory permissions: %v", err)
-			}
-		}()
-		if err != nil {
-			t.Fatalf("Failed to change directory permissions: %v", err)
-		}
-
-		pkg.SetCurFile(incPath, incPath, true, true, false)
-		err = pkg.WritePkgFiles()
+	t.Run("WriteUnexistFile", func(t *testing.T) {
+		pkg := createTestPkg(t, &convert.PackageConfig{})
+		err := pkg.Write("test1.h")
 		if err == nil {
 			t.Fatal("Expected an error for invalid output directory, but got nil")
 		}

--- a/cmd/gogensig/convert/package_test.go
+++ b/cmd/gogensig/convert/package_test.go
@@ -329,7 +329,8 @@ func TestPackageWrite(t *testing.T) {
 			t.Fatalf("Failed to change directory permissions: %v", err)
 		}
 
-		err = pkg.Write(incPath)
+		pkg.SetCurFile(incPath, incPath, true, true, false)
+		err = pkg.WritePkgFiles()
 		if err == nil {
 			t.Fatal("Expected an error for invalid output directory, but got nil")
 		}


### PR DESCRIPTION
fix #59 
- 修复存在多个向前声明不应该出现的错误输出。
- 修改文件集合遍历结束时再初始化向前声明及文件写出，以修复向前声明在被引用的文件中实现时，过早的标识为完成，导致实际的声明实现没有正确输出，