### PR TITLE
gogensig:ensure consistent param name in func sig

### DIFF
--- a/cmd/gogensig/convert/_testdata/funcrefer/conf/llcppg.symb.json
+++ b/cmd/gogensig/convert/_testdata/funcrefer/conf/llcppg.symb.json
@@ -5,6 +5,11 @@
     "go": "Exec"
   },
   {
+    "mangle": "mprintf",
+    "c++": "mprintf",
+    "go": "Mprintf"
+  },
+  {
     "mangle": "OSSL_provider_init2",
     "c++": "OSSL_provider_init2",
     "go": "ProviderInit2"

--- a/cmd/gogensig/convert/_testdata/funcrefer/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/funcrefer/gogensig.expect
@@ -9,6 +9,8 @@ import (
 type CallBack func(unsafe.Pointer) c.Int
 //go:linkname Exec C.exec
 func Exec(L unsafe.Pointer, cb CallBack)
+//go:linkname Mprintf C.mprintf
+func Mprintf(__llgo_arg_0 *int8, __llgo_va_list ...interface{}) *int8
 
 type Hooks struct {
 	MallocFn unsafe.Pointer
@@ -41,7 +43,7 @@ type OsslLibCtxSt struct {
 }
 type OSSLLIBCTX OsslLibCtxSt
 //go:linkname ProviderAddBuiltin C.OSSL_PROVIDER_add_builtin
-func ProviderAddBuiltin(*OSSLLIBCTX, name *int8, init_fn OSSLProviderInitFn2) c.Int
+func ProviderAddBuiltin(__llgo_arg_0 *OSSLLIBCTX, name *int8, init_fn OSSLProviderInitFn2) c.Int
 
 ===== llcppg.pub =====
 CallBack

--- a/cmd/gogensig/convert/_testdata/funcrefer/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/funcrefer/hfile/temp.h
@@ -2,6 +2,7 @@
 #include <stdio.h>
 typedef int (*CallBack)(void *L);
 void exec(void *L, CallBack cb);
+char *mprintf(const char*,...);
 
 typedef struct Hooks
 {

--- a/cmd/gogensig/convert/_testdata/sqlite/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/sqlite/gogensig.expect
@@ -36,7 +36,7 @@ func (p *Sqlite3) CloseV2() c.Int {
 // llgo:type C
 type Callback func(unsafe.Pointer, c.Int, **int8, **int8) c.Int
 // llgo:link (*Sqlite3).Exec C.sqlite3_exec
-func (p *Sqlite3) Exec(sql *int8, callback func(unsafe.Pointer, c.Int, **int8, **int8) c.Int, unsafe.Pointer, errmsg **int8) c.Int {
+func (p *Sqlite3) Exec(sql *int8, callback func(unsafe.Pointer, c.Int, **int8, **int8) c.Int, __llgo_arg_2 unsafe.Pointer, errmsg **int8) c.Int {
 	return 0
 }
 


### PR DESCRIPTION
fix #77 
修复函数签名中存在未命名和命名参数的问题，函数签名中一旦存在命名的参数，其他参数名即以参数索引作为缺省值
before 
```
func (p *Sqlite3) Exec(sql *int8, callback func(unsafe.Pointer, c.Int, **int8, **int8) c.Int, unsafe.Pointer, errmsg **int8) c.Int
```
after:
```
func (p *Sqlite3) Exec(sql *int8, callback func(unsafe.Pointer, c.Int, **int8, **int8) c.Int, __llgo_arg_2 unsafe.Pointer, errmsg **int8) c.Int
```