### PR TITLE
[wip] ci:test convert no panic

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -75,6 +75,10 @@ jobs:
       if: startsWith(matrix.os, 'macos')
       run: go test -v -coverprofile="coverage.txt" -covermode=atomic ./...
 
+    - name: Test Convert Success
+      if: startsWith(matrix.os, 'macos')
+      run: llcppgtest libcjson
+
     - name: Test demos
       run: |
         # TODO(lijie): force python3-embed to be linked with python-3.12-embed

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -77,7 +77,9 @@ jobs:
 
     - name: Test Convert Success
       if: startsWith(matrix.os, 'macos')
-      run: llcppgtest libcjson
+      run: | 
+        llcppgtest libcjson
+        llcppgtest openssl
 
     - name: Test demos
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,7 +79,6 @@ jobs:
       if: startsWith(matrix.os, 'macos')
       run: | 
         llcppgtest libcjson
-        llcppgtest openssl
 
     - name: Test demos
       run: |

--- a/.github/workflows/install_llcppg_modules.sh
+++ b/.github/workflows/install_llcppg_modules.sh
@@ -9,3 +9,4 @@ go install ./cmd/llcppgtest
 llgo install ./_xtool/llcppsymg
 llgo install ./_xtool/llcppsigfetch
 go install ./cmd/gogensig
+go install .

--- a/.github/workflows/install_llcppg_modules.sh
+++ b/.github/workflows/install_llcppg_modules.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# for test
+go install ./cmd/llcppcfg
+go install ./cmd/llcppgtest
+
+# main process required
 llgo install ./_xtool/llcppsymg
 llgo install ./_xtool/llcppsigfetch
 go install ./cmd/gogensig

--- a/llcppg.go
+++ b/llcppg.go
@@ -96,6 +96,7 @@ func main() {
 
 func check(err error) {
 	if err != nil {
-		panic(err)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1) // trigger github action failure
 	}
 }


### PR DESCRIPTION
用于保证原先出现转换错误的第三方库，不会由于更新发生错误。