### PR TITLE
[wip] gogensig: typedef havent defined type cause panic 

### DIFF
--- a/_xtool/llcppsigfetch/parse/cvt.go
+++ b/_xtool/llcppsigfetch/parse/cvt.go
@@ -246,6 +246,7 @@ func (ct *Converter) visitTop(cursor, parent clang.Cursor) clang.ChildVisitResul
 			return clang.ChildVisit_Continue
 		}
 		curFile.Includes = append(curFile.Includes, include)
+		curFile.Decls = append(curFile.Decls, include)
 		ct.logln("visitTop: ProcessInclude END ", include.Path)
 	case clang.CursorMacroDefinition:
 		macro := ct.ProcessMacro(cursor)

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/llgo.expect
@@ -12,6 +12,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"Foo"
 				},
 				"Type":	{
@@ -27,6 +28,10 @@
 										"_Type":	"TagExpr",
 										"Name":	{
 											"_Type":	"Ident",
+											"DefLoc":	{
+												"_Type":	"Location",
+												"File":	"./hfile/forwarddecl.h"
+											},
 											"Name":	"bar"
 										},
 										"Tag":	0
@@ -38,6 +43,7 @@
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"b"
 									}]
 							}]
@@ -54,6 +60,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"bar"
 				},
 				"Type":	{
@@ -74,6 +81,7 @@
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}]
@@ -90,6 +98,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"sqlite3_pcache_page"
 				},
 				"Type":	{
@@ -111,6 +120,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"sqlite3_pcache_page"
 				},
 				"Type":	{
@@ -134,6 +144,7 @@
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"pExtra"
 									}]
 							}]
@@ -150,6 +161,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"sqlite3_pcache"
 				},
 				"Type":	{
@@ -171,6 +183,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"sqlite3_pcache_methods2"
 				},
 				"Type":	{
@@ -192,6 +205,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"sqlite3_pcache_methods2"
 				},
 				"Type":	{
@@ -212,6 +226,7 @@
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"iVersion"
 									}]
 							}, {
@@ -252,6 +267,7 @@
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"xShutdown"
 									}]
 							}, {
@@ -304,6 +320,10 @@
 											"_Type":	"PointerType",
 											"X":	{
 												"_Type":	"Ident",
+												"DefLoc":	{
+													"_Type":	"Location",
+													"File":	"./hfile/forwarddecl.h"
+												},
 												"Name":	"sqlite3_pcache"
 											}
 										}
@@ -315,6 +335,7 @@
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"xCreate"
 									}]
 							}]
@@ -331,6 +352,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"sqlite3_file"
 				},
 				"Type":	{
@@ -352,6 +374,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"sqlite3_file"
 				},
 				"Type":	{
@@ -365,6 +388,10 @@
 									"_Type":	"PointerType",
 									"X":	{
 										"_Type":	"Ident",
+										"DefLoc":	{
+											"_Type":	"Location",
+											"File":	"./hfile/forwarddecl.h"
+										},
 										"Name":	"sqlite3_io_methods"
 									}
 								},
@@ -374,6 +401,7 @@
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"pMethods"
 									}]
 							}]
@@ -390,6 +418,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"sqlite3_io_methods"
 				},
 				"Type":	{
@@ -411,6 +440,10 @@
 														"_Type":	"PointerType",
 														"X":	{
 															"_Type":	"Ident",
+															"DefLoc":	{
+																"_Type":	"Location",
+																"File":	"./hfile/forwarddecl.h"
+															},
 															"Name":	"sqlite3_file"
 														}
 													},
@@ -461,6 +494,7 @@
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"xUnfetch"
 									}]
 							}]
@@ -477,6 +511,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"lua_State"
 				},
 				"Type":	{
@@ -498,6 +533,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"lua_Debug"
 				},
 				"Type":	{
@@ -519,6 +555,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"lua_getstack"
 				},
 				"MangledName":	"lua_getstack",
@@ -532,6 +569,10 @@
 									"_Type":	"PointerType",
 									"X":	{
 										"_Type":	"Ident",
+										"DefLoc":	{
+											"_Type":	"Location",
+											"File":	"./hfile/forwarddecl.h"
+										},
 										"Name":	"lua_State"
 									}
 								},
@@ -541,6 +582,7 @@
 								"Access":	0,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"L"
 									}]
 							}, {
@@ -556,6 +598,7 @@
 								"Access":	0,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"level"
 									}]
 							}, {
@@ -564,6 +607,10 @@
 									"_Type":	"PointerType",
 									"X":	{
 										"_Type":	"Ident",
+										"DefLoc":	{
+											"_Type":	"Location",
+											"File":	"./hfile/forwarddecl.h"
+										},
 										"Name":	"lua_Debug"
 									}
 								},
@@ -573,6 +620,7 @@
 								"Access":	0,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"ar"
 									}]
 							}]
@@ -601,6 +649,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"lua_Debug"
 				},
 				"Type":	{
@@ -629,6 +678,7 @@
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"short_src"
 									}]
 							}, {
@@ -639,6 +689,10 @@
 										"_Type":	"TagExpr",
 										"Name":	{
 											"_Type":	"Ident",
+											"DefLoc":	{
+												"_Type":	"Location",
+												"File":	""
+											},
 											"Name":	"CallInfo"
 										},
 										"Tag":	0
@@ -650,6 +704,7 @@
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"i_ci"
 									}]
 							}]
@@ -678,9 +733,6 @@
 	"./hfile/def.h":	{
 		"_Type":	"File",
 		"decls":	[{
-				"_Type":	"Include",
-				"Path":	"./hfile/impl.h"
-			}, {
 				"_Type":	"FuncDecl",
 				"Loc":	{
 					"_Type":	"Location",
@@ -690,6 +742,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"f"
 				},
 				"MangledName":	"f",
@@ -703,6 +756,10 @@
 									"_Type":	"PointerType",
 									"X":	{
 										"_Type":	"Ident",
+										"DefLoc":	{
+											"_Type":	"Location",
+											"File":	"./hfile/def.h"
+										},
 										"Name":	"foo"
 									}
 								},
@@ -712,6 +769,7 @@
 								"Access":	0,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"f"
 									}]
 							}]
@@ -749,6 +807,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"Type":	{
@@ -769,6 +828,7 @@
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}]

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/forwarddecl_test/llgo.expect
@@ -678,6 +678,9 @@
 	"./hfile/def.h":	{
 		"_Type":	"File",
 		"decls":	[{
+				"_Type":	"Include",
+				"Path":	"./hfile/impl.h"
+			}, {
 				"_Type":	"FuncDecl",
 				"Loc":	{
 					"_Type":	"Location",

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/include_test/hfile/compact.h
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/include_test/hfile/compact.h
@@ -1,0 +1,1 @@
+typedef gnutls_cipher_algorithm_t gnutls_cipher_algorithm;

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/include_test/hfile/temp.h
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/include_test/hfile/temp.h
@@ -1,0 +1,6 @@
+typedef enum gnutls_cipher_algorithm {
+    GNUTLS_CIPHER_UNKNOWN = 0,
+    GNUTLS_CIPHER_NULL = 1,
+} gnutls_cipher_algorithm_t;
+
+#include <compact.h>

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/include_test/include.go
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/include_test/include.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	test "github.com/goplus/llcppg/_xtool/llcppsigfetch/parse/cvt_test"
+	"github.com/goplus/llcppg/_xtool/llcppsymg/clangutils"
+)
+
+func main() {
+	TestInclude()
+}
+
+func TestInclude() {
+	test.RunTestWithConfig(&clangutils.Config{
+		File:  "./hfile/temp.h",
+		Temp:  false,
+		IsCpp: false,
+	})
+}

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/include_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/include_test/llgo.expect
@@ -3,6 +3,9 @@
 	"./hfile/temp.h":	{
 		"_Type":	"File",
 		"decls":	[{
+				"_Type":	"Include",
+				"Path":	"./hfile/compact.h"
+			}, {
 				"_Type":	"EnumTypeDecl",
 				"Loc":	{
 					"_Type":	"Location",

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/include_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/include_test/llgo.expect
@@ -3,9 +3,6 @@
 	"./hfile/temp.h":	{
 		"_Type":	"File",
 		"decls":	[{
-				"_Type":	"Include",
-				"Path":	"./hfile/compact.h"
-			}, {
 				"_Type":	"EnumTypeDecl",
 				"Loc":	{
 					"_Type":	"Location",
@@ -15,6 +12,7 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"gnutls_cipher_algorithm"
 				},
 				"Type":	{
@@ -23,6 +21,7 @@
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"GNUTLS_CIPHER_UNKNOWN"
 							},
 							"Value":	{
@@ -34,6 +33,7 @@
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"GNUTLS_CIPHER_NULL"
 							},
 							"Value":	{
@@ -53,12 +53,17 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"gnutls_cipher_algorithm_t"
 				},
 				"Type":	{
 					"_Type":	"TagExpr",
 					"Name":	{
 						"_Type":	"Ident",
+						"DefLoc":	{
+							"_Type":	"Location",
+							"File":	"./hfile/temp.h"
+						},
 						"Name":	"gnutls_cipher_algorithm"
 					},
 					"Tag":	2
@@ -82,10 +87,15 @@
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"gnutls_cipher_algorithm"
 				},
 				"Type":	{
 					"_Type":	"Ident",
+					"DefLoc":	{
+						"_Type":	"Location",
+						"File":	"./hfile/temp.h"
+					},
 					"Name":	"gnutls_cipher_algorithm_t"
 				}
 			}],

--- a/_xtool/llcppsigfetch/parse/cvt_test/complex_test/include_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/complex_test/include_test/llgo.expect
@@ -1,0 +1,97 @@
+#stdout
+{
+	"./hfile/temp.h":	{
+		"_Type":	"File",
+		"decls":	[{
+				"_Type":	"EnumTypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"gnutls_cipher_algorithm"
+				},
+				"Type":	{
+					"_Type":	"EnumType",
+					"Items":	[{
+							"_Type":	"EnumItem",
+							"Name":	{
+								"_Type":	"Ident",
+								"Name":	"GNUTLS_CIPHER_UNKNOWN"
+							},
+							"Value":	{
+								"_Type":	"BasicLit",
+								"Kind":	0,
+								"Value":	"0"
+							}
+						}, {
+							"_Type":	"EnumItem",
+							"Name":	{
+								"_Type":	"Ident",
+								"Name":	"GNUTLS_CIPHER_NULL"
+							},
+							"Value":	{
+								"_Type":	"BasicLit",
+								"Kind":	0,
+								"Value":	"1"
+							}
+						}]
+				}
+			}, {
+				"_Type":	"TypedefDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"gnutls_cipher_algorithm_t"
+				},
+				"Type":	{
+					"_Type":	"TagExpr",
+					"Name":	{
+						"_Type":	"Ident",
+						"Name":	"gnutls_cipher_algorithm"
+					},
+					"Tag":	2
+				}
+			}],
+		"includes":	[{
+				"_Type":	"Include",
+				"Path":	"./hfile/compact.h"
+			}],
+		"macros":	[]
+	},
+	"./hfile/compact.h":	{
+		"_Type":	"File",
+		"decls":	[{
+				"_Type":	"TypedefDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./hfile/compact.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"gnutls_cipher_algorithm"
+				},
+				"Type":	{
+					"_Type":	"Ident",
+					"Name":	"gnutls_cipher_algorithm_t"
+				}
+			}],
+		"includes":	[],
+		"macros":	[]
+	}
+}
+
+
+#stderr
+
+#exit 0

--- a/_xtool/llcppsigfetch/parse/cvt_test/decl_test/class_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/decl_test/class_test/llgo.expect
@@ -13,6 +13,7 @@ TestClassDecl Case 1:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"A"
 				},
 				"Type":	{
@@ -33,6 +34,7 @@ TestClassDecl Case 1:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}, {
@@ -48,6 +50,7 @@ TestClassDecl Case 1:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"b"
 									}]
 							}]
@@ -74,6 +77,7 @@ TestClassDecl Case 2:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"A"
 				},
 				"Type":	{
@@ -94,6 +98,7 @@ TestClassDecl Case 2:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}, {
@@ -109,6 +114,7 @@ TestClassDecl Case 2:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"b"
 									}]
 							}]
@@ -122,10 +128,15 @@ TestClassDecl Case 2:
 							"Doc":	null,
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"A"
 							},
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"foo"
 							},
 							"MangledName":	"_ZN1A3fooEid",
@@ -146,6 +157,7 @@ TestClassDecl Case 2:
 											"Access":	0,
 											"Names":	[{
 													"_Type":	"Ident",
+													"DefLoc":	null,
 													"Name":	"a"
 												}]
 										}, {
@@ -161,6 +173,7 @@ TestClassDecl Case 2:
 											"Access":	0,
 											"Names":	[{
 													"_Type":	"Ident",
+													"DefLoc":	null,
 													"Name":	"b"
 												}]
 										}]
@@ -201,6 +214,7 @@ TestClassDecl Case 3:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"A"
 				},
 				"Type":	{
@@ -219,10 +233,15 @@ TestClassDecl Case 3:
 							"Doc":	null,
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"A"
 							},
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"A"
 							},
 							"MangledName":	"_ZN1AC1Ev",
@@ -255,10 +274,15 @@ TestClassDecl Case 3:
 							"Doc":	null,
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"A"
 							},
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"A"
 							},
 							"MangledName":	"_ZN1AC1Ev",
@@ -291,10 +315,15 @@ TestClassDecl Case 3:
 							"Doc":	null,
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"A"
 							},
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"~A"
 							},
 							"MangledName":	"_ZN1AD1Ev",
@@ -327,10 +356,15 @@ TestClassDecl Case 3:
 							"Doc":	null,
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"A"
 							},
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"foo"
 							},
 							"MangledName":	"_ZN1A3fooEv",
@@ -376,6 +410,7 @@ TestClassDecl Case 4:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"Base"
 				},
 				"Type":	{
@@ -394,10 +429,15 @@ TestClassDecl Case 4:
 							"Doc":	null,
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"Base"
 							},
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"Base"
 							},
 							"MangledName":	"_ZN4BaseC1Ev",
@@ -430,10 +470,15 @@ TestClassDecl Case 4:
 							"Doc":	null,
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"Base"
 							},
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"~Base"
 							},
 							"MangledName":	"_ZN4BaseD1Ev",
@@ -466,10 +511,15 @@ TestClassDecl Case 4:
 							"Doc":	null,
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"Base"
 							},
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"foo"
 							},
 							"MangledName":	"_ZN4Base3fooEv",
@@ -505,6 +555,7 @@ TestClassDecl Case 4:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"Derived"
 				},
 				"Type":	{
@@ -523,10 +574,15 @@ TestClassDecl Case 4:
 							"Doc":	null,
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"Derived"
 							},
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"Derived"
 							},
 							"MangledName":	"_ZN7DerivedC1Ev",
@@ -559,10 +615,15 @@ TestClassDecl Case 4:
 							"Doc":	null,
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"Derived"
 							},
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"~Derived"
 							},
 							"MangledName":	"_ZN7DerivedD1Ev",
@@ -595,10 +656,15 @@ TestClassDecl Case 4:
 							"Doc":	null,
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"Derived"
 							},
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"foo"
 							},
 							"MangledName":	"_ZN7Derived3fooEv",
@@ -643,10 +709,15 @@ TestClassDecl Case 5:
 				"Doc":	null,
 				"Parent":	{
 					"_Type":	"Ident",
+					"DefLoc":	{
+						"_Type":	"Location",
+						"File":	"temp.h"
+					},
 					"Name":	"A"
 				},
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"Foo"
 				},
 				"Type":	{
@@ -669,15 +740,21 @@ TestClassDecl Case 5:
 					"_Type":	"ScopingExpr",
 					"X":	{
 						"_Type":	"Ident",
+						"DefLoc":	null,
 						"Name":	"Foo"
 					},
 					"Parent":	{
 						"_Type":	"Ident",
+						"DefLoc":	{
+							"_Type":	"Location",
+							"File":	"temp.h"
+						},
 						"Name":	"A"
 					}
 				},
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"bar"
 				},
 				"MangledName":	"_ZN1A3Foo3barEv",

--- a/_xtool/llcppsigfetch/parse/cvt_test/decl_test/comment_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/decl_test/comment_test/llgo.expect
@@ -13,6 +13,7 @@ TestDoc Case 1:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3foov",
@@ -56,6 +57,7 @@ TestDoc Case 2:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3foov",
@@ -105,6 +107,7 @@ TestDoc Case 3:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3foov",
@@ -154,6 +157,7 @@ TestDoc Case 4:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3foov",
@@ -203,6 +207,7 @@ TestDoc Case 5:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3foov",
@@ -255,6 +260,7 @@ TestDoc Case 6:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3foov",
@@ -307,6 +313,7 @@ TestDoc Case 7:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3foov",
@@ -359,6 +366,7 @@ TestDoc Case 8:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3foov",
@@ -417,6 +425,7 @@ TestDoc Case 9:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3foov",
@@ -460,6 +469,7 @@ TestDoc Case 10:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"Foo"
 				},
 				"Type":	{
@@ -486,6 +496,7 @@ TestDoc Case 10:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"x"
 									}]
 							}, {
@@ -507,6 +518,7 @@ TestDoc Case 10:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"y"
 									}]
 							}, {
@@ -528,6 +540,7 @@ TestDoc Case 10:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"z"
 									}]
 							}]
@@ -554,6 +567,7 @@ TestDoc Case 11:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"Doc"
 				},
 				"Type":	{
@@ -586,6 +600,7 @@ TestDoc Case 11:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"x"
 									}]
 							}, {
@@ -607,6 +622,7 @@ TestDoc Case 11:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"y"
 									}]
 							}, {
@@ -634,6 +650,7 @@ TestDoc Case 11:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}, {
@@ -655,6 +672,7 @@ TestDoc Case 11:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"b"
 									}]
 							}, {
@@ -676,6 +694,7 @@ TestDoc Case 11:
 								"Access":	2,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"value"
 									}]
 							}]
@@ -701,10 +720,15 @@ TestDoc Case 11:
 							},
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"Doc"
 							},
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"Foo"
 							},
 							"MangledName":	"_ZN3Doc3FooEv",

--- a/_xtool/llcppsigfetch/parse/cvt_test/decl_test/enum_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/decl_test/enum_test/llgo.expect
@@ -18,6 +18,7 @@ TestEnumDecl Case 1:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"a"
 							},
 							"Value":	{
@@ -29,6 +30,7 @@ TestEnumDecl Case 1:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"b"
 							},
 							"Value":	{
@@ -40,6 +42,7 @@ TestEnumDecl Case 1:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"c"
 							},
 							"Value":	{
@@ -69,6 +72,7 @@ TestEnumDecl Case 2:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"Foo"
 				},
 				"Type":	{
@@ -77,6 +81,7 @@ TestEnumDecl Case 2:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"a"
 							},
 							"Value":	{
@@ -88,6 +93,7 @@ TestEnumDecl Case 2:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"b"
 							},
 							"Value":	{
@@ -99,6 +105,7 @@ TestEnumDecl Case 2:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"c"
 							},
 							"Value":	{
@@ -128,6 +135,7 @@ TestEnumDecl Case 3:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"Foo"
 				},
 				"Type":	{
@@ -136,6 +144,7 @@ TestEnumDecl Case 3:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"a"
 							},
 							"Value":	{
@@ -147,6 +156,7 @@ TestEnumDecl Case 3:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"b"
 							},
 							"Value":	{
@@ -158,6 +168,7 @@ TestEnumDecl Case 3:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"c"
 							},
 							"Value":	{
@@ -187,6 +198,7 @@ TestEnumDecl Case 4:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"Foo"
 				},
 				"Type":	{
@@ -195,6 +207,7 @@ TestEnumDecl Case 4:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"a"
 							},
 							"Value":	{
@@ -206,6 +219,7 @@ TestEnumDecl Case 4:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"b"
 							},
 							"Value":	{
@@ -217,6 +231,7 @@ TestEnumDecl Case 4:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"c"
 							},
 							"Value":	{

--- a/_xtool/llcppsigfetch/parse/cvt_test/decl_test/func_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/decl_test/func_test/llgo.expect
@@ -13,6 +13,7 @@ TestFuncDecl Case 1:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3foov",
@@ -56,6 +57,7 @@ TestFuncDecl Case 2:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3fooi",
@@ -76,6 +78,7 @@ TestFuncDecl Case 2:
 								"Access":	0,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}]
@@ -114,6 +117,7 @@ TestFuncDecl Case 3:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3fooiz",
@@ -134,6 +138,7 @@ TestFuncDecl Case 3:
 								"Access":	0,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}, {
@@ -182,6 +187,7 @@ TestFuncDecl Case 4:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3fooid",
@@ -202,6 +208,7 @@ TestFuncDecl Case 4:
 								"Access":	0,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}, {
@@ -217,6 +224,7 @@ TestFuncDecl Case 4:
 								"Access":	0,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"b"
 									}]
 							}]
@@ -258,6 +266,7 @@ TestFuncDecl Case 5:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"add"
 				},
 				"MangledName":	"_ZL3addii",
@@ -278,6 +287,7 @@ TestFuncDecl Case 5:
 								"Access":	0,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}, {
@@ -293,6 +303,7 @@ TestFuncDecl Case 5:
 								"Access":	0,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"b"
 									}]
 							}]
@@ -331,6 +342,7 @@ TestFuncDecl Case 6:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"fntype"
 				},
 				"Type":	{
@@ -355,6 +367,7 @@ TestFuncDecl Case 6:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3foov",
@@ -398,6 +411,7 @@ TestFuncDecl Case 7:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"fntype"
 				},
 				"Type":	{
@@ -434,10 +448,15 @@ TestFuncDecl Case 7:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"fntype2"
 				},
 				"Type":	{
 					"_Type":	"Ident",
+					"DefLoc":	{
+						"_Type":	"Location",
+						"File":	"temp.h"
+					},
 					"Name":	"fntype"
 				}
 			}, {
@@ -450,6 +469,7 @@ TestFuncDecl Case 7:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3fool",
@@ -505,6 +525,7 @@ TestFuncDecl Case 8:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"OSSL_CORE_HANDLE"
 				},
 				"Type":	{
@@ -526,6 +547,7 @@ TestFuncDecl Case 8:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"OSSL_DISPATCH"
 				},
 				"Type":	{
@@ -547,6 +569,7 @@ TestFuncDecl Case 8:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"OSSL_provider_init_fn"
 				},
 				"Type":	{
@@ -559,6 +582,10 @@ TestFuncDecl Case 8:
 									"_Type":	"PointerType",
 									"X":	{
 										"_Type":	"Ident",
+										"DefLoc":	{
+											"_Type":	"Location",
+											"File":	"temp.h"
+										},
 										"Name":	"OSSL_CORE_HANDLE"
 									}
 								},
@@ -573,6 +600,10 @@ TestFuncDecl Case 8:
 									"_Type":	"PointerType",
 									"X":	{
 										"_Type":	"Ident",
+										"DefLoc":	{
+											"_Type":	"Location",
+											"File":	"temp.h"
+										},
 										"Name":	"OSSL_DISPATCH"
 									}
 								},
@@ -589,6 +620,10 @@ TestFuncDecl Case 8:
 										"_Type":	"PointerType",
 										"X":	{
 											"_Type":	"Ident",
+											"DefLoc":	{
+												"_Type":	"Location",
+												"File":	"temp.h"
+											},
 											"Name":	"OSSL_DISPATCH"
 										}
 									}
@@ -634,6 +669,7 @@ TestFuncDecl Case 8:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"OSSL_provider_init"
 				},
 				"MangledName":	"_Z18OSSL_provider_initPK16OSSL_CORE_HANDLEPK13OSSL_DISPATCHPS4_PPv",
@@ -647,6 +683,10 @@ TestFuncDecl Case 8:
 									"_Type":	"PointerType",
 									"X":	{
 										"_Type":	"Ident",
+										"DefLoc":	{
+											"_Type":	"Location",
+											"File":	"temp.h"
+										},
 										"Name":	"OSSL_CORE_HANDLE"
 									}
 								},
@@ -661,6 +701,10 @@ TestFuncDecl Case 8:
 									"_Type":	"PointerType",
 									"X":	{
 										"_Type":	"Ident",
+										"DefLoc":	{
+											"_Type":	"Location",
+											"File":	"temp.h"
+										},
 										"Name":	"OSSL_DISPATCH"
 									}
 								},
@@ -677,6 +721,10 @@ TestFuncDecl Case 8:
 										"_Type":	"PointerType",
 										"X":	{
 											"_Type":	"Ident",
+											"DefLoc":	{
+												"_Type":	"Location",
+												"File":	"temp.h"
+											},
 											"Name":	"OSSL_DISPATCH"
 										}
 									}

--- a/_xtool/llcppsigfetch/parse/cvt_test/decl_test/scope_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/decl_test/scope_test/llgo.expect
@@ -13,6 +13,7 @@ TestScope Case 1:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_Z3foov",
@@ -55,10 +56,15 @@ TestScope Case 2:
 				"Doc":	null,
 				"Parent":	{
 					"_Type":	"Ident",
+					"DefLoc":	{
+						"_Type":	"Location",
+						"File":	"temp.h"
+					},
 					"Name":	"a"
 				},
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_ZN1a3fooEv",
@@ -103,15 +109,21 @@ TestScope Case 3:
 					"_Type":	"ScopingExpr",
 					"X":	{
 						"_Type":	"Ident",
+						"DefLoc":	null,
 						"Name":	"b"
 					},
 					"Parent":	{
 						"_Type":	"Ident",
+						"DefLoc":	{
+							"_Type":	"Location",
+							"File":	"temp.h"
+						},
 						"Name":	"a"
 					}
 				},
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"foo"
 				},
 				"MangledName":	"_ZN1a1b3fooEv",
@@ -155,6 +167,7 @@ TestScope Case 4:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"a"
 				},
 				"Type":	{
@@ -173,10 +186,15 @@ TestScope Case 4:
 							"Doc":	null,
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"a"
 							},
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"foo"
 							},
 							"MangledName":	"_ZN1a3fooEv",
@@ -221,10 +239,15 @@ TestScope Case 5:
 				"Doc":	null,
 				"Parent":	{
 					"_Type":	"Ident",
+					"DefLoc":	{
+						"_Type":	"Location",
+						"File":	"temp.h"
+					},
 					"Name":	"a"
 				},
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"b"
 				},
 				"Type":	{
@@ -245,15 +268,21 @@ TestScope Case 5:
 								"_Type":	"ScopingExpr",
 								"X":	{
 									"_Type":	"Ident",
+									"DefLoc":	null,
 									"Name":	"b"
 								},
 								"Parent":	{
 									"_Type":	"Ident",
+									"DefLoc":	{
+										"_Type":	"Location",
+										"File":	"temp.h"
+									},
 									"Name":	"a"
 								}
 							},
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"foo"
 							},
 							"MangledName":	"_ZN1a1b3fooEv",

--- a/_xtool/llcppsigfetch/parse/cvt_test/decl_test/struct_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/decl_test/struct_test/llgo.expect
@@ -30,6 +30,7 @@ TestStructDecl Case 1:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}]
@@ -56,6 +57,7 @@ TestStructDecl Case 2:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"A"
 				},
 				"Type":	{
@@ -76,6 +78,7 @@ TestStructDecl Case 2:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}, {
@@ -91,6 +94,7 @@ TestStructDecl Case 2:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"b"
 									}]
 							}]
@@ -117,6 +121,7 @@ TestStructDecl Case 3:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"A"
 				},
 				"Type":	{
@@ -137,6 +142,7 @@ TestStructDecl Case 3:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}, {
@@ -152,6 +158,7 @@ TestStructDecl Case 3:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"b"
 									}]
 							}]
@@ -178,6 +185,7 @@ TestStructDecl Case 4:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"A"
 				},
 				"Type":	{
@@ -198,6 +206,7 @@ TestStructDecl Case 4:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}, {
@@ -247,6 +256,7 @@ TestStructDecl Case 4:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"Foo"
 									}]
 							}]
@@ -273,6 +283,7 @@ TestStructDecl Case 5:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"Person"
 				},
 				"Type":	{
@@ -293,6 +304,7 @@ TestStructDecl Case 5:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"age"
 									}]
 							}, {
@@ -315,6 +327,7 @@ TestStructDecl Case 5:
 												"Access":	1,
 												"Names":	[{
 														"_Type":	"Ident",
+														"DefLoc":	null,
 														"Name":	"year"
 													}]
 											}, {
@@ -330,6 +343,7 @@ TestStructDecl Case 5:
 												"Access":	1,
 												"Names":	[{
 														"_Type":	"Ident",
+														"DefLoc":	null,
 														"Name":	"day"
 													}]
 											}, {
@@ -345,6 +359,7 @@ TestStructDecl Case 5:
 												"Access":	1,
 												"Names":	[{
 														"_Type":	"Ident",
+														"DefLoc":	null,
 														"Name":	"month"
 													}]
 											}]
@@ -357,6 +372,7 @@ TestStructDecl Case 5:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"birthday"
 									}]
 							}]

--- a/_xtool/llcppsigfetch/parse/cvt_test/decl_test/typedef_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/decl_test/typedef_test/llgo.expect
@@ -13,6 +13,7 @@ TestTypeDefDecl Case 1:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"INT"
 				},
 				"Type":	{
@@ -40,6 +41,7 @@ TestTypeDefDecl Case 2:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"INT"
 				},
 				"Type":	{
@@ -57,10 +59,15 @@ TestTypeDefDecl Case 2:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"STANDARD_INT"
 				},
 				"Type":	{
 					"_Type":	"Ident",
+					"DefLoc":	{
+						"_Type":	"Location",
+						"File":	"temp.h"
+					},
 					"Name":	"INT"
 				}
 			}],
@@ -83,6 +90,7 @@ TestTypeDefDecl Case 3:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"INT"
 				},
 				"Type":	{
@@ -100,6 +108,7 @@ TestTypeDefDecl Case 3:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"IntPtr"
 				},
 				"Type":	{
@@ -120,6 +129,7 @@ TestTypeDefDecl Case 3:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"IntArr"
 				},
 				"Type":	{
@@ -151,6 +161,7 @@ TestTypeDefDecl Case 4:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"Foo"
 				},
 				"Type":	{
@@ -222,6 +233,7 @@ TestTypeDefDecl Case 5:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"Foo"
 				},
 				"Type":	{
@@ -273,6 +285,7 @@ TestTypeDefDecl Case 5:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"Bar"
 				},
 				"Type":	{
@@ -339,10 +352,15 @@ TestTypeDefDecl Case 6:
 				"Doc":	null,
 				"Parent":	{
 					"_Type":	"Ident",
+					"DefLoc":	{
+						"_Type":	"Location",
+						"File":	"temp.h"
+					},
 					"Name":	"A"
 				},
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"Foo"
 				},
 				"Type":	{
@@ -363,6 +381,7 @@ TestTypeDefDecl Case 6:
 								"Access":	3,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"x"
 									}]
 							}]
@@ -378,10 +397,15 @@ TestTypeDefDecl Case 6:
 				"Doc":	null,
 				"Parent":	{
 					"_Type":	"Ident",
+					"DefLoc":	{
+						"_Type":	"Location",
+						"File":	"temp.h"
+					},
 					"Name":	"A"
 				},
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"MyClass"
 				},
 				"Type":	{
@@ -390,10 +414,15 @@ TestTypeDefDecl Case 6:
 						"_Type":	"ScopingExpr",
 						"X":	{
 							"_Type":	"Ident",
+							"DefLoc":	null,
 							"Name":	"Foo"
 						},
 						"Parent":	{
 							"_Type":	"Ident",
+							"DefLoc":	{
+								"_Type":	"Location",
+								"File":	"temp.h"
+							},
 							"Name":	"A"
 						}
 					},
@@ -408,10 +437,15 @@ TestTypeDefDecl Case 6:
 				"Doc":	null,
 				"Parent":	{
 					"_Type":	"Ident",
+					"DefLoc":	{
+						"_Type":	"Location",
+						"File":	"temp.h"
+					},
 					"Name":	"A"
 				},
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"MyClassPtr"
 				},
 				"Type":	{
@@ -422,10 +456,15 @@ TestTypeDefDecl Case 6:
 							"_Type":	"ScopingExpr",
 							"X":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"Foo"
 							},
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"A"
 							}
 						},
@@ -441,10 +480,15 @@ TestTypeDefDecl Case 6:
 				"Doc":	null,
 				"Parent":	{
 					"_Type":	"Ident",
+					"DefLoc":	{
+						"_Type":	"Location",
+						"File":	"temp.h"
+					},
 					"Name":	"A"
 				},
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"MyClassArray"
 				},
 				"Type":	{
@@ -455,10 +499,15 @@ TestTypeDefDecl Case 6:
 							"_Type":	"ScopingExpr",
 							"X":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"Foo"
 							},
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"A"
 							}
 						},
@@ -486,6 +535,7 @@ TestTypeDefDecl Case 7:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"MyStruct"
 				},
 				"Type":	{
@@ -506,6 +556,7 @@ TestTypeDefDecl Case 7:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"x"
 									}]
 							}]
@@ -532,6 +583,7 @@ TestTypeDefDecl Case 8:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"MyUnion"
 				},
 				"Type":	{
@@ -552,6 +604,7 @@ TestTypeDefDecl Case 8:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"x"
 									}]
 							}]
@@ -578,6 +631,7 @@ TestTypeDefDecl Case 9:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"MyEnum"
 				},
 				"Type":	{
@@ -586,6 +640,7 @@ TestTypeDefDecl Case 9:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"RED"
 							},
 							"Value":	{
@@ -597,6 +652,7 @@ TestTypeDefDecl Case 9:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"GREEN"
 							},
 							"Value":	{
@@ -608,6 +664,7 @@ TestTypeDefDecl Case 9:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"BLUE"
 							},
 							"Value":	{
@@ -637,6 +694,7 @@ TestTypeDefDecl Case 10:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"MyStruct"
 				},
 				"Type":	{
@@ -657,6 +715,7 @@ TestTypeDefDecl Case 10:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"x"
 									}]
 							}]
@@ -673,12 +732,17 @@ TestTypeDefDecl Case 10:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"MyStruct2"
 				},
 				"Type":	{
 					"_Type":	"TagExpr",
 					"Name":	{
 						"_Type":	"Ident",
+						"DefLoc":	{
+							"_Type":	"Location",
+							"File":	"temp.h"
+						},
 						"Name":	"MyStruct"
 					},
 					"Tag":	0
@@ -693,6 +757,7 @@ TestTypeDefDecl Case 10:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"StructPtr"
 				},
 				"Type":	{
@@ -701,6 +766,10 @@ TestTypeDefDecl Case 10:
 						"_Type":	"TagExpr",
 						"Name":	{
 							"_Type":	"Ident",
+							"DefLoc":	{
+								"_Type":	"Location",
+								"File":	"temp.h"
+							},
 							"Name":	"MyStruct"
 						},
 						"Tag":	0
@@ -716,6 +785,7 @@ TestTypeDefDecl Case 10:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"StructArr"
 				},
 				"Type":	{
@@ -724,6 +794,10 @@ TestTypeDefDecl Case 10:
 						"_Type":	"TagExpr",
 						"Name":	{
 							"_Type":	"Ident",
+							"DefLoc":	{
+								"_Type":	"Location",
+								"File":	"temp.h"
+							},
 							"Name":	"MyStruct"
 						},
 						"Tag":	0
@@ -750,6 +824,7 @@ TestTypeDefDecl Case 11:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"MyEnum"
 				},
 				"Type":	{
@@ -758,6 +833,7 @@ TestTypeDefDecl Case 11:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"RED"
 							},
 							"Value":	{
@@ -769,6 +845,7 @@ TestTypeDefDecl Case 11:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"GREEN"
 							},
 							"Value":	{
@@ -780,6 +857,7 @@ TestTypeDefDecl Case 11:
 							"_Type":	"EnumItem",
 							"Name":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"BLUE"
 							},
 							"Value":	{
@@ -799,12 +877,17 @@ TestTypeDefDecl Case 11:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"MyEnum2"
 				},
 				"Type":	{
 					"_Type":	"TagExpr",
 					"Name":	{
 						"_Type":	"Ident",
+						"DefLoc":	{
+							"_Type":	"Location",
+							"File":	"temp.h"
+						},
 						"Name":	"MyEnum"
 					},
 					"Tag":	2
@@ -819,6 +902,7 @@ TestTypeDefDecl Case 11:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"EnumPtr"
 				},
 				"Type":	{
@@ -827,6 +911,10 @@ TestTypeDefDecl Case 11:
 						"_Type":	"TagExpr",
 						"Name":	{
 							"_Type":	"Ident",
+							"DefLoc":	{
+								"_Type":	"Location",
+								"File":	"temp.h"
+							},
 							"Name":	"MyEnum"
 						},
 						"Tag":	2
@@ -842,6 +930,7 @@ TestTypeDefDecl Case 11:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"EnumArr"
 				},
 				"Type":	{
@@ -850,6 +939,10 @@ TestTypeDefDecl Case 11:
 						"_Type":	"TagExpr",
 						"Name":	{
 							"_Type":	"Ident",
+							"DefLoc":	{
+								"_Type":	"Location",
+								"File":	"temp.h"
+							},
 							"Name":	"MyEnum"
 						},
 						"Tag":	2
@@ -877,15 +970,21 @@ TestTypeDefDecl Case 12:
 					"_Type":	"ScopingExpr",
 					"X":	{
 						"_Type":	"Ident",
+						"DefLoc":	null,
 						"Name":	"B"
 					},
 					"Parent":	{
 						"_Type":	"Ident",
+						"DefLoc":	{
+							"_Type":	"Location",
+							"File":	"temp.h"
+						},
 						"Name":	"A"
 					}
 				},
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"MyStruct"
 				},
 				"Type":	{
@@ -906,6 +1005,7 @@ TestTypeDefDecl Case 12:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"x"
 									}]
 							}]
@@ -923,15 +1023,21 @@ TestTypeDefDecl Case 12:
 					"_Type":	"ScopingExpr",
 					"X":	{
 						"_Type":	"Ident",
+						"DefLoc":	null,
 						"Name":	"B"
 					},
 					"Parent":	{
 						"_Type":	"Ident",
+						"DefLoc":	{
+							"_Type":	"Location",
+							"File":	"temp.h"
+						},
 						"Name":	"A"
 					}
 				},
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"MyStruct2"
 				},
 				"Type":	{
@@ -940,16 +1046,22 @@ TestTypeDefDecl Case 12:
 						"_Type":	"ScopingExpr",
 						"X":	{
 							"_Type":	"Ident",
+							"DefLoc":	null,
 							"Name":	"MyStruct"
 						},
 						"Parent":	{
 							"_Type":	"ScopingExpr",
 							"X":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"B"
 							},
 							"Parent":	{
 								"_Type":	"Ident",
+								"DefLoc":	{
+									"_Type":	"Location",
+									"File":	"temp.h"
+								},
 								"Name":	"A"
 							}
 						}
@@ -967,15 +1079,21 @@ TestTypeDefDecl Case 12:
 					"_Type":	"ScopingExpr",
 					"X":	{
 						"_Type":	"Ident",
+						"DefLoc":	null,
 						"Name":	"B"
 					},
 					"Parent":	{
 						"_Type":	"Ident",
+						"DefLoc":	{
+							"_Type":	"Location",
+							"File":	"temp.h"
+						},
 						"Name":	"A"
 					}
 				},
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"StructPtr"
 				},
 				"Type":	{
@@ -986,16 +1104,22 @@ TestTypeDefDecl Case 12:
 							"_Type":	"ScopingExpr",
 							"X":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"MyStruct"
 							},
 							"Parent":	{
 								"_Type":	"ScopingExpr",
 								"X":	{
 									"_Type":	"Ident",
+									"DefLoc":	null,
 									"Name":	"B"
 								},
 								"Parent":	{
 									"_Type":	"Ident",
+									"DefLoc":	{
+										"_Type":	"Location",
+										"File":	"temp.h"
+									},
 									"Name":	"A"
 								}
 							}
@@ -1014,15 +1138,21 @@ TestTypeDefDecl Case 12:
 					"_Type":	"ScopingExpr",
 					"X":	{
 						"_Type":	"Ident",
+						"DefLoc":	null,
 						"Name":	"B"
 					},
 					"Parent":	{
 						"_Type":	"Ident",
+						"DefLoc":	{
+							"_Type":	"Location",
+							"File":	"temp.h"
+						},
 						"Name":	"A"
 					}
 				},
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"StructArr"
 				},
 				"Type":	{
@@ -1033,16 +1163,22 @@ TestTypeDefDecl Case 12:
 							"_Type":	"ScopingExpr",
 							"X":	{
 								"_Type":	"Ident",
+								"DefLoc":	null,
 								"Name":	"MyStruct"
 							},
 							"Parent":	{
 								"_Type":	"ScopingExpr",
 								"X":	{
 									"_Type":	"Ident",
+									"DefLoc":	null,
 									"Name":	"B"
 								},
 								"Parent":	{
 									"_Type":	"Ident",
+									"DefLoc":	{
+										"_Type":	"Location",
+										"File":	"temp.h"
+									},
 									"Name":	"A"
 								}
 							}

--- a/_xtool/llcppsigfetch/parse/cvt_test/decl_test/union_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/decl_test/union_test/llgo.expect
@@ -30,6 +30,7 @@ TestUnionDecl Case 1:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}, {
@@ -45,6 +46,7 @@ TestUnionDecl Case 1:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"b"
 									}]
 							}]
@@ -71,6 +73,7 @@ TestUnionDecl Case 2:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"A"
 				},
 				"Type":	{
@@ -91,6 +94,7 @@ TestUnionDecl Case 2:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"a"
 									}]
 							}, {
@@ -106,6 +110,7 @@ TestUnionDecl Case 2:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"b"
 									}]
 							}]
@@ -132,6 +137,7 @@ TestUnionDecl Case 3:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"OuterUnion"
 				},
 				"Type":	{
@@ -152,6 +158,7 @@ TestUnionDecl Case 3:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"i"
 									}]
 							}, {
@@ -167,6 +174,7 @@ TestUnionDecl Case 3:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"f"
 									}]
 							}, {
@@ -189,6 +197,7 @@ TestUnionDecl Case 3:
 												"Access":	1,
 												"Names":	[{
 														"_Type":	"Ident",
+														"DefLoc":	null,
 														"Name":	"c"
 													}]
 											}, {
@@ -204,6 +213,7 @@ TestUnionDecl Case 3:
 												"Access":	1,
 												"Names":	[{
 														"_Type":	"Ident",
+														"DefLoc":	null,
 														"Name":	"s"
 													}]
 											}]
@@ -216,6 +226,7 @@ TestUnionDecl Case 3:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"inner"
 									}]
 							}]

--- a/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/llgo.expect
@@ -125,9 +125,6 @@ TestMacroExpansionOtherFile:
 	"./testdata/macroexpan/ref.h":	{
 		"_Type":	"File",
 		"decls":	[{
-				"_Type":	"Include",
-				"Path":	"./testdata/macroexpan/def.h"
-			}, {
 				"_Type":	"TypeDecl",
 				"Loc":	{
 					"_Type":	"Location",
@@ -137,6 +134,7 @@ TestMacroExpansionOtherFile:
 				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
+					"DefLoc":	null,
 					"Name":	"NewType"
 				},
 				"Type":	{
@@ -165,6 +163,7 @@ TestMacroExpansionOtherFile:
 								"Access":	1,
 								"Names":	[{
 										"_Type":	"Ident",
+										"DefLoc":	null,
 										"Name":	"__val"
 									}]
 							}]

--- a/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/llgo.expect
@@ -125,6 +125,9 @@ TestMacroExpansionOtherFile:
 	"./testdata/macroexpan/ref.h":	{
 		"_Type":	"File",
 		"decls":	[{
+				"_Type":	"Include",
+				"Path":	"./testdata/macroexpan/def.h"
+			}, {
 				"_Type":	"TypeDecl",
 				"Loc":	{
 					"_Type":	"Location",

--- a/_xtool/llcppsigfetch/parse/cvt_test/type_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/type_test/llgo.expect
@@ -118,6 +118,10 @@ Type: int &&:
 Type: Foo:
 {
 	"_Type":	"Ident",
+	"DefLoc":	{
+		"_Type":	"Location",
+		"File":	"temp.h"
+	},
 	"Name":	"Foo"
 }
 Type: struct Foo:
@@ -125,6 +129,10 @@ Type: struct Foo:
 	"_Type":	"TagExpr",
 	"Name":	{
 		"_Type":	"Ident",
+		"DefLoc":	{
+			"_Type":	"Location",
+			"File":	"temp.h"
+		},
 		"Name":	"Foo"
 	},
 	"Tag":	0
@@ -148,6 +156,7 @@ Type: struct (unnamed struct at temp.h:1:1):
 				"Access":	1,
 				"Names":	[{
 						"_Type":	"Ident",
+						"DefLoc":	null,
 						"Name":	"x"
 					}]
 			}]
@@ -157,6 +166,10 @@ Type: struct (unnamed struct at temp.h:1:1):
 Type: Foo:
 {
 	"_Type":	"Ident",
+	"DefLoc":	{
+		"_Type":	"Location",
+		"File":	"temp.h"
+	},
 	"Name":	"Foo"
 }
 Type: union Foo:
@@ -164,6 +177,10 @@ Type: union Foo:
 	"_Type":	"TagExpr",
 	"Name":	{
 		"_Type":	"Ident",
+		"DefLoc":	{
+			"_Type":	"Location",
+			"File":	"temp.h"
+		},
 		"Name":	"Foo"
 	},
 	"Tag":	1
@@ -187,6 +204,7 @@ Type: union (unnamed union at temp.h:1:1):
 				"Access":	1,
 				"Names":	[{
 						"_Type":	"Ident",
+						"DefLoc":	null,
 						"Name":	"x"
 					}]
 			}]
@@ -196,6 +214,10 @@ Type: union (unnamed union at temp.h:1:1):
 Type: Foo:
 {
 	"_Type":	"Ident",
+	"DefLoc":	{
+		"_Type":	"Location",
+		"File":	"temp.h"
+	},
 	"Name":	"Foo"
 }
 Type: enum Foo:
@@ -203,6 +225,10 @@ Type: enum Foo:
 	"_Type":	"TagExpr",
 	"Name":	{
 		"_Type":	"Ident",
+		"DefLoc":	{
+			"_Type":	"Location",
+			"File":	"temp.h"
+		},
 		"Name":	"Foo"
 	},
 	"Tag":	2
@@ -214,6 +240,7 @@ Type: enum (unnamed enum at temp.h:1:1):
 			"_Type":	"EnumItem",
 			"Name":	{
 				"_Type":	"Ident",
+				"DefLoc":	null,
 				"Name":	"x"
 			},
 			"Value":	{
@@ -226,6 +253,10 @@ Type: enum (unnamed enum at temp.h:1:1):
 Type: Foo:
 {
 	"_Type":	"Ident",
+	"DefLoc":	{
+		"_Type":	"Location",
+		"File":	"temp.h"
+	},
 	"Name":	"Foo"
 }
 Type: class Foo:
@@ -233,6 +264,10 @@ Type: class Foo:
 	"_Type":	"TagExpr",
 	"Name":	{
 		"_Type":	"Ident",
+		"DefLoc":	{
+			"_Type":	"Location",
+			"File":	"temp.h"
+		},
 		"Name":	"Foo"
 	},
 	"Tag":	3
@@ -256,6 +291,7 @@ Type: class (unnamed class at temp.h:1:1):
 				"Access":	3,
 				"Names":	[{
 						"_Type":	"Ident",
+						"DefLoc":	null,
 						"Name":	"x"
 					}]
 			}]
@@ -267,16 +303,22 @@ Type: a::b::c:
 	"_Type":	"ScopingExpr",
 	"X":	{
 		"_Type":	"Ident",
+		"DefLoc":	null,
 		"Name":	"c"
 	},
 	"Parent":	{
 		"_Type":	"ScopingExpr",
 		"X":	{
 			"_Type":	"Ident",
+			"DefLoc":	null,
 			"Name":	"b"
 		},
 		"Parent":	{
 			"_Type":	"Ident",
+			"DefLoc":	{
+				"_Type":	"Location",
+				"File":	"temp.h"
+			},
 			"Name":	"a"
 		}
 	}
@@ -288,16 +330,22 @@ Type: class a::b::c:
 		"_Type":	"ScopingExpr",
 		"X":	{
 			"_Type":	"Ident",
+			"DefLoc":	null,
 			"Name":	"c"
 		},
 		"Parent":	{
 			"_Type":	"ScopingExpr",
 			"X":	{
 				"_Type":	"Ident",
+				"DefLoc":	null,
 				"Name":	"b"
 			},
 			"Parent":	{
 				"_Type":	"Ident",
+				"DefLoc":	{
+					"_Type":	"Location",
+					"File":	"temp.h"
+				},
 				"Name":	"a"
 			}
 		}

--- a/_xtool/llcppsigfetch/parse/dump.go
+++ b/_xtool/llcppsigfetch/parse/dump.go
@@ -116,9 +116,6 @@ func MarshalASTDecl(decl ast.Decl) *cjson.JSON {
 	}
 	root := cjson.Object()
 	switch d := decl.(type) {
-	case *ast.Include:
-		root.SetItem(c.Str("_Type"), stringField("Include"))
-		root.SetItem(c.Str("Path"), stringField(d.Path))
 	case *ast.EnumTypeDecl:
 		root.SetItem(c.Str("_Type"), stringField("EnumTypeDecl"))
 		MarshalASTDeclBase(d.DeclBase, root)
@@ -153,12 +150,19 @@ func MarshalASTDecl(decl ast.Decl) *cjson.JSON {
 }
 
 func MarshalASTDeclBase(decl ast.DeclBase, root *cjson.JSON) {
-	loc := cjson.Object()
-	loc.SetItem(c.Str("_Type"), stringField("Location"))
-	loc.SetItem(c.Str("File"), stringField(decl.Loc.File))
-	root.SetItem(c.Str("Loc"), loc)
+	root.SetItem(c.Str("Loc"), MarshalASTLocation(decl.Loc))
 	root.SetItem(c.Str("Doc"), MarshalASTExpr(decl.Doc))
 	root.SetItem(c.Str("Parent"), MarshalASTExpr(decl.Parent))
+}
+
+func MarshalASTLocation(loc *ast.Location) *cjson.JSON {
+	if loc == nil {
+		return cjson.Null()
+	}
+	root := cjson.Object()
+	root.SetItem(c.Str("_Type"), stringField("Location"))
+	root.SetItem(c.Str("File"), stringField(loc.File))
+	return root
 }
 
 func MarshalASTExpr(t ast.Expr) *cjson.JSON {
@@ -207,10 +211,11 @@ func MarshalASTExpr(t ast.Expr) *cjson.JSON {
 	case *ast.Variadic:
 		root.SetItem(c.Str("_Type"), stringField("Variadic"))
 	case *ast.Ident:
-		root.SetItem(c.Str("_Type"), stringField("Ident"))
 		if d == nil {
 			return cjson.Null()
 		}
+		root.SetItem(c.Str("_Type"), stringField("Ident"))
+		root.SetItem(c.Str("DefLoc"), MarshalASTLocation(d.DefLoc))
 		root.SetItem(c.Str("Name"), stringField(d.Name))
 	case *ast.TagExpr:
 		root.SetItem(c.Str("_Type"), stringField("TagExpr"))

--- a/_xtool/llcppsigfetch/parse/dump.go
+++ b/_xtool/llcppsigfetch/parse/dump.go
@@ -116,6 +116,9 @@ func MarshalASTDecl(decl ast.Decl) *cjson.JSON {
 	}
 	root := cjson.Object()
 	switch d := decl.(type) {
+	case *ast.Include:
+		root.SetItem(c.Str("_Type"), stringField("Include"))
+		root.SetItem(c.Str("Path"), stringField(d.Path))
 	case *ast.EnumTypeDecl:
 		root.SetItem(c.Str("_Type"), stringField("EnumTypeDecl"))
 		MarshalASTDeclBase(d.DeclBase, root)

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -352,7 +352,8 @@ type Include struct {
 	Path string `json:"path"`
 }
 
-func (*Include) ppdNode() {}
+func (*Include) ppdNode()  {}
+func (*Include) declNode() {}
 
 // ------------------------------------------------
 

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -114,7 +114,8 @@ func (*BuiltinType) exprNode() {}
 
 // Name
 type Ident struct {
-	Name string
+	Name   string
+	DefLoc *Location
 }
 
 func (*Ident) exprNode() {}
@@ -352,8 +353,7 @@ type Include struct {
 	Path string `json:"path"`
 }
 
-func (*Include) ppdNode()  {}
-func (*Include) declNode() {}
+func (*Include) ppdNode() {}
 
 // ------------------------------------------------
 

--- a/cmd/gogensig/convert/_testdata/enum/conf/llcppg.cfg
+++ b/cmd/gogensig/convert/_testdata/enum/conf/llcppg.cfg
@@ -1,5 +1,5 @@
 {
   "name": "enum",
-  "include": ["temp.h"],
+  "include": ["temp.h","compact.h"],
   "cplusplus":false
 }

--- a/cmd/gogensig/convert/_testdata/enum/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/enum/hfile/temp.h
@@ -1,3 +1,4 @@
+
 enum { enum1, enum2 };
 enum spectrum { red, orange, yello, green, blue, violet };
 
@@ -17,4 +18,4 @@ typedef enum {
     NULL2 = 1,
 } algorithm_t2;
 
-typedef algorithm_t algorithm;
+#include <compact.h>

--- a/cmd/gogensig/convert/package.go
+++ b/cmd/gogensig/convert/package.go
@@ -243,7 +243,7 @@ func (p *Package) NewTypeDecl(typeDecl *ast.TypeDecl) error {
 	skip, anony, err := p.cvt.handleSysType(typeDecl.Name, typeDecl.Loc, p.curFile.sysIncPath)
 	if skip {
 		if debug {
-			log.Printf("NewTypeDecl: %s type of system header\n", typeDecl.Name)
+			log.Printf("NewTypeDecl: %s type of system header\n", typeDecl.Name.Name)
 		}
 		return err
 	}


### PR DESCRIPTION
#61 

gnutls/gnutls.h
```
typedef enum gnutls_cipher_algorithm {
	GNUTLS_CIPHER_UNKNOWN = 0,
	GNUTLS_CIPHER_NULL = 1,
} gnutls_cipher_algorithm_t;

#include <gnutls/compat.h>
```
gnutls/compat.h 
```
typedef gnutls_cipher_algorithm_t gnutls_cipher_algorithm
	_GNUTLS_GCC_ATTR_DEPRECATED;
```

经过调查，发现是因为在gnutls/gnutls.h的底部，才引入<gnutls/compat.h>,而目前的处理逻辑是，对于一个头文件，先处理其include列表，处理结束后，才会处理本来的头文件，这就导致了gogensig 先处理gnutls/compat.h 的时候，gnutls_cipher_algorithm_t这个类型还没定义



#### 可能的解决方案
llcppsigfetch 中能正确获得gnutls/compat.h中underlying type的原因是其遵守了C编译顺序，即先完成了类型的定义，再执行了include引入，所以这个引用顺序是没有错误的，能正确描述类型定义。而gogensig的头文件依赖关系的处理为无论这个include节点的位置在某个头文件的何处，都会先访问被include的文件。

目前存在两种解决方案

1. 将gogensig的处理头文件的顺序，修改处理为与C语言的一致，即将include节点视为一个一般的声明节点，存在顺序，碰到include节点，就先处理对应include的文件转换，这个能保证更能正确的描述C语言的结构。
    - 经过尝试，发现获得的include并不是按照源文件顺序 https://github.com/goplus/llcppg/pull/88/commits/da2f978f82046a85d6b190f84545e858567a30f2


2. 不修改整体处理逻辑，但补充处理到某个类型时，查看其对应节点的定义位置的头文件，是否已经被处理，如果没有被处理，那就优先访问转换。

  -  llcppsigfetch：保留位置信息，处理到某个类型时，查看其头文件是否已经被处理，如果对应类型某个头文件还没访问，那么优先处理对应的头文件。对于这个用例来说，即检查这个gnutls_cipher_algorithm_t 对应的头文件是否被处理，如果没有被处理，那么先处理该文件。


* 正在考虑与Go一致，llcppsigfetch提供一些类型信息，用于存放映射或者定义关系