### PR TITLE
gogensig:fix unexpect receiver duplicate init

### DIFF
--- a/cmd/gogensig/convert/_testdata/receiver/conf/llcppg.cfg
+++ b/cmd/gogensig/convert/_testdata/receiver/conf/llcppg.cfg
@@ -1,0 +1,5 @@
+{
+  "name": "comment",
+  "include": ["temp.h","use.h"],
+  "cplusplus":false
+}

--- a/cmd/gogensig/convert/_testdata/receiver/conf/llcppg.symb.json
+++ b/cmd/gogensig/convert/_testdata/receiver/conf/llcppg.symb.json
@@ -1,0 +1,7 @@
+[
+  {
+    "mangle": "ares_dns_addr_to_ptr",
+    "c++": "ares_dns_addr_to_ptr(const struct ares_addr *)",
+    "go": "(*aresAddr).AresDnsAddrToPtr"
+  }
+]

--- a/cmd/gogensig/convert/_testdata/receiver/conf/llcppg.symb.json
+++ b/cmd/gogensig/convert/_testdata/receiver/conf/llcppg.symb.json
@@ -1,5 +1,10 @@
 [
   {
+    "mangle": "ares_dns_pton",
+    "c++": "ares_dns_pton(const char *, struct ares_addr *, int *)",
+    "go": "AresDnsPton"
+  },
+  {
     "mangle": "ares_dns_addr_to_ptr",
     "c++": "ares_dns_addr_to_ptr(const struct ares_addr *)",
     "go": "(*aresAddr).AresDnsAddrToPtr"

--- a/cmd/gogensig/convert/_testdata/receiver/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/receiver/gogensig.expect
@@ -1,0 +1,43 @@
+===== temp.go =====
+package receiver
+
+import (
+	"github.com/goplus/llgo/c"
+	_ "unsafe"
+)
+
+type X__Uint32T c.Uint
+type InAddrT X__Uint32T
+
+type InAddr struct {
+	SAddr InAddrT
+}
+
+type AresIn6Addr struct {
+	X_S6Un struct {
+		X_S6U8 [16]int8
+	}
+}
+
+===== use.go =====
+package receiver
+
+import _ "unsafe"
+
+type AresAddr struct {
+	Family c.Int
+	Addr   struct {
+		Addr6 AresIn6Addr
+	}
+}
+// llgo:link (*aresAddr).AresDnsAddrToPtr C.ares_dns_addr_to_ptr
+func (p *AresAddr) AresDnsAddrToPtr() *int8 {
+	return nil
+}
+
+===== llcppg.pub =====
+__uint32_t X__Uint32T
+ares_addr AresAddr
+ares_in6_addr AresIn6Addr
+in_addr InAddr
+in_addr_t InAddrT

--- a/cmd/gogensig/convert/_testdata/receiver/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/receiver/gogensig.expect
@@ -6,11 +6,8 @@ import (
 	_ "unsafe"
 )
 
-type X__Uint32T c.Uint
-type InAddrT X__Uint32T
-
-type InAddr struct {
-	SAddr InAddrT
+type InAddr1 struct {
+	SAddr c.Uint
 }
 
 type AresIn6Addr struct {
@@ -22,7 +19,7 @@ type AresIn6Addr struct {
 ===== use.go =====
 package receiver
 
-import _ "unsafe"
+import "unsafe"
 
 type AresAddr struct {
 	Family c.Int
@@ -30,14 +27,14 @@ type AresAddr struct {
 		Addr6 AresIn6Addr
 	}
 }
+//go:linkname AresDnsPton C.ares_dns_pton
+func AresDnsPton(ipaddr *int8, addr *AresAddr) unsafe.Pointer
 // llgo:link (*aresAddr).AresDnsAddrToPtr C.ares_dns_addr_to_ptr
 func (p *AresAddr) AresDnsAddrToPtr() *int8 {
 	return nil
 }
 
 ===== llcppg.pub =====
-__uint32_t X__Uint32T
 ares_addr AresAddr
 ares_in6_addr AresIn6Addr
-in_addr InAddr
-in_addr_t InAddrT
+in_addr1 InAddr1

--- a/cmd/gogensig/convert/_testdata/receiver/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/receiver/hfile/temp.h
@@ -1,7 +1,5 @@
-typedef unsigned int __uint32_t;
-typedef __uint32_t in_addr_t;
-struct in_addr {
-    in_addr_t s_addr;
+struct in_addr1 {
+    unsigned int s_addr;
 };
 
 struct ares_in6_addr {
@@ -14,7 +12,7 @@ struct ares_addr {
     int family;
 
     union {
-        struct in_addr addr4;
+        struct in_addr1 addr4;
         struct ares_in6_addr addr6;
     } addr;
 };

--- a/cmd/gogensig/convert/_testdata/receiver/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/receiver/hfile/temp.h
@@ -1,0 +1,22 @@
+typedef unsigned int __uint32_t;
+typedef __uint32_t in_addr_t;
+struct in_addr {
+    in_addr_t s_addr;
+};
+
+struct ares_in6_addr {
+    union {
+        unsigned char _S6_u8[16];
+    } _S6_un;
+};
+
+struct ares_addr {
+    int family;
+
+    union {
+        struct in_addr addr4;
+        struct ares_in6_addr addr6;
+    } addr;
+};
+
+#include "use.h"

--- a/cmd/gogensig/convert/_testdata/receiver/hfile/use.h
+++ b/cmd/gogensig/convert/_testdata/receiver/hfile/use.h
@@ -1,0 +1,2 @@
+
+char *ares_dns_addr_to_ptr(const struct ares_addr *addr);

--- a/cmd/gogensig/convert/_testdata/receiver/hfile/use.h
+++ b/cmd/gogensig/convert/_testdata/receiver/hfile/use.h
@@ -1,2 +1,3 @@
-
+// todo(zzy): ares_addr need generate in the temp.go
+const void *ares_dns_pton(const char *ipaddr, struct ares_addr *addr);
 char *ares_dns_addr_to_ptr(const struct ares_addr *addr);

--- a/cmd/gogensig/convert/package.go
+++ b/cmd/gogensig/convert/package.go
@@ -297,6 +297,9 @@ func (p *Package) handleCompleteType(decl *gogen.TypeDecl, typ *ast.RecordType, 
 // For such declarations, create a empty type decl and store it in the
 // incomplete map, but not in the public symbol table.
 func (p *Package) handleImplicitForwardDecl(name string) *gogen.TypeDecl {
+	if decl, ok := p.incomplete[name]; ok {
+		return decl
+	}
 	pubName := p.nameMapper.GetGoName(name, p.trimPrefixes())
 	decl := p.emptyTypeDecl(pubName, nil)
 	p.incomplete[name] = decl

--- a/cmd/gogensig/convert/type.go
+++ b/cmd/gogensig/convert/type.go
@@ -211,9 +211,13 @@ func (p *TypeConv) ToSignature(funcType *ast.FuncType, recv *types.Var) (*types.
 	ctx := p.ctx
 	p.ctx = Param
 	defer func() { p.ctx = ctx }()
-	params, variadic, err := p.fieldListToParams(funcType.Params)
+	var params *types.Tuple
+	var variadic bool
+	var err error
 	if recv != nil {
 		params, variadic, err = p.fieldListToParams(&ast.FieldList{List: funcType.Params.List[1:]})
+	} else {
+		params, variadic, err = p.fieldListToParams(funcType.Params)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
fix https://github.com/goplus/llcppg/issues/67
* 对于处理为receiver的函数，阻止不预期的对receiver的重复获取
* 对于重复的隐式前向声明，进行复用，而不是重新创建导致重复声明

对于issue中的libcares 的redefine问题已经可以解决
```json
{
	"name": "libcares",
	"cflags": "$(pkg-config --cflags libcares)",
	"libs": "$(pkg-config --libs libcares)",
	"include": [
		"ares.h",
		"ares_dns_record.h"
	],
	"deps": null,
	"trimPrefixes": [],
	"cplusplus": false
}
```
仅保留预期的 /c/unix/net 没有引用的错误
```
2024/12/25 19:18:06 NewFuncDecl ares_dns_rr_set_u8 Fail: ares_dns_rr_set_u8 symbol not found
2024/12/25 19:18:06 NewFuncDecl: &{ares_dns_rr_set_u16}
2024/12/25 19:18:06 NewFuncDecl ares_dns_rr_set_u16 Fail: ares_dns_rr_set_u16 symbol not found
2024/12/25 19:18:06 NewFuncDecl: &{ares_dns_rr_set_u32}
2024/12/25 19:18:06 NewFuncDecl ares_dns_rr_set_u32 Fail: ares_dns_rr_set_u32 symbol not found
2024/12/25 19:18:06 NewFuncDecl: &{ares_dns_rr_set_bin}
2024/12/25 19:18:06 NewFuncDecl ares_dns_rr_set_bin Fail: ares_dns_rr_set_bin symbol not found
2024/12/25 19:18:06 NewFuncDecl: &{ares_dns_rr_add_abin}
2024/12/25 19:18:06 NewFuncDecl ares_dns_rr_add_abin Fail: ares_dns_rr_add_abin symbol not found
2024/12/25 19:18:06 NewFuncDecl: &{ares_dns_rr_del_abin}
2024/12/25 19:18:06 NewFuncDecl ares_dns_rr_del_abin Fail: ares_dns_rr_del_abin symbol not found
2024/12/25 19:18:06 NewFuncDecl: &{ares_dns_rr_set_opt}
2024/12/25 19:18:06 NewFuncDecl ares_dns_rr_set_opt Fail: ares_dns_rr_set_opt symbol not found
2024/12/25 19:18:06 NewFuncDecl: &{ares_dns_rr_del_opt_byid}
2024/12/25 19:18:06 NewFuncDecl ares_dns_rr_del_opt_byid Fail: ares_dns_rr_del_opt_byid symbol not found
2024/12/25 19:18:06 NewFuncDecl: &{ares_dns_rr_get_addr}
panic: no required module provides package github.com/goplus/llgo/c/unix/net; to add it:
        go get github.com/goplus/llgo/c/unix/net

```

#### 复现
```json
{
	"name": "libcares",
	"cflags": "$(pkg-config --cflags libcares)",
	"libs": "$(pkg-config --libs libcares)",
	"include": [
		"ares.h",
		"ares_dns_record.h"
	],
	"deps": null,
	"trimPrefixes": [],
	"cplusplus": false
}
```

`ares.h`
```c
#include <netinet/in.h>
#include <sys/socket.h>
#include <sys/types.h>
struct ares_in6_addr {
    union {
        unsigned char _S6_u8[16];
    } _S6_un;
};

struct ares_addr {
    int family;

    union {
        struct in_addr addr4;
        struct ares_in6_addr addr6;
    } addr;
};

#include "ares_dns_record.h"
```
`ares_dns_record.h`
```
char *ares_dns_addr_to_ptr(const struct ares_addr *addr);
```
llcppg.symb.json
```json
[
  {
    "mangle": "ares_dns_addr_to_ptr",
    "c++": "ares_dns_addr_to_ptr(const struct ares_addr *)",
    "go": "(*Struct aresAddr).AresDnsAddrToPtr"
  }
]
```
问题出现在将这个const struct ares_addr *addr 作为receiver初始化后，仍然将整个paramlist进行初始化了
