### PR TITLE
gogensig:link comment use same receiver in signature 

### DIFF
--- a/cmd/gogensig/convert/_testdata/cjson/conf/llcppg.pub
+++ b/cmd/gogensig/convert/_testdata/cjson/conf/llcppg.pub
@@ -1,0 +1,2 @@
+cJSON JSON
+cJSON_bool CustomBool

--- a/cmd/gogensig/convert/_testdata/cjson/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/cjson/gogensig.expect
@@ -6,10 +6,10 @@ import (
 	"unsafe"
 )
 
-type CJSON struct {
-	Next        *CJSON
-	Prev        *CJSON
-	Child       *CJSON
+type JSON struct {
+	Next        *JSON
+	Prev        *JSON
+	Child       *JSON
 	Type        c.Int
 	Valuestring *int8
 	Valueint    c.Int
@@ -21,264 +21,264 @@ type Hooks struct {
 	MallocFn unsafe.Pointer
 	FreeFn   unsafe.Pointer
 }
-type Bool c.Int
+type CustomBool c.Int
 //go:linkname Version C.cJSON_Version
 func Version() *int8
 // llgo:link (*Hooks).InitHooks C.cJSON_InitHooks
 func (recv_ *Hooks) InitHooks() {
 }
 //go:linkname Parse C.cJSON_Parse
-func Parse(value *int8) *CJSON
+func Parse(value *int8) *JSON
 //go:linkname ParseWithLength C.cJSON_ParseWithLength
-func ParseWithLength(value *int8, buffer_length uintptr) *CJSON
+func ParseWithLength(value *int8, buffer_length uintptr) *JSON
 //go:linkname ParseWithOpts C.cJSON_ParseWithOpts
-func ParseWithOpts(value *int8, return_parse_end **int8, require_null_terminated Bool) *CJSON
+func ParseWithOpts(value *int8, return_parse_end **int8, require_null_terminated CustomBool) *JSON
 //go:linkname ParseWithLengthOpts C.cJSON_ParseWithLengthOpts
-func ParseWithLengthOpts(value *int8, buffer_length uintptr, return_parse_end **int8, require_null_terminated Bool) *CJSON
-// llgo:link (*CJSON).Print C.cJSON_Print
-func (recv_ *CJSON) Print() *int8 {
+func ParseWithLengthOpts(value *int8, buffer_length uintptr, return_parse_end **int8, require_null_terminated CustomBool) *JSON
+// llgo:link (*JSON).Print C.cJSON_Print
+func (recv_ *JSON) Print() *int8 {
 	return nil
 }
-// llgo:link (*CJSON).PrintUnformatted C.cJSON_PrintUnformatted
-func (recv_ *CJSON) PrintUnformatted() *int8 {
+// llgo:link (*JSON).PrintUnformatted C.cJSON_PrintUnformatted
+func (recv_ *JSON) PrintUnformatted() *int8 {
 	return nil
 }
-// llgo:link (*CJSON).PrintBuffered C.cJSON_PrintBuffered
-func (recv_ *CJSON) PrintBuffered(prebuffer c.Int, fmt Bool) *int8 {
+// llgo:link (*JSON).PrintBuffered C.cJSON_PrintBuffered
+func (recv_ *JSON) PrintBuffered(prebuffer c.Int, fmt CustomBool) *int8 {
 	return nil
 }
-// llgo:link (*CJSON).PrintPreallocated C.cJSON_PrintPreallocated
-func (recv_ *CJSON) PrintPreallocated(buffer *int8, length c.Int, format Bool) Bool {
+// llgo:link (*JSON).PrintPreallocated C.cJSON_PrintPreallocated
+func (recv_ *JSON) PrintPreallocated(buffer *int8, length c.Int, format CustomBool) CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).Delete C.cJSON_Delete
-func (recv_ *CJSON) Delete() {
+// llgo:link (*JSON).Delete C.cJSON_Delete
+func (recv_ *JSON) Delete() {
 }
-// llgo:link (*CJSON).GetArraySize C.cJSON_GetArraySize
-func (recv_ *CJSON) GetArraySize() c.Int {
+// llgo:link (*JSON).GetArraySize C.cJSON_GetArraySize
+func (recv_ *JSON) GetArraySize() c.Int {
 	return 0
 }
-// llgo:link (*CJSON).GetArrayItem C.cJSON_GetArrayItem
-func (recv_ *CJSON) GetArrayItem(index c.Int) *CJSON {
+// llgo:link (*JSON).GetArrayItem C.cJSON_GetArrayItem
+func (recv_ *JSON) GetArrayItem(index c.Int) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).GetObjectItem C.cJSON_GetObjectItem
-func (recv_ *CJSON) GetObjectItem(string *int8) *CJSON {
+// llgo:link (*JSON).GetObjectItem C.cJSON_GetObjectItem
+func (recv_ *JSON) GetObjectItem(string *int8) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).GetObjectItemCaseSensitive C.cJSON_GetObjectItemCaseSensitive
-func (recv_ *CJSON) GetObjectItemCaseSensitive(string *int8) *CJSON {
+// llgo:link (*JSON).GetObjectItemCaseSensitive C.cJSON_GetObjectItemCaseSensitive
+func (recv_ *JSON) GetObjectItemCaseSensitive(string *int8) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).HasObjectItem C.cJSON_HasObjectItem
-func (recv_ *CJSON) HasObjectItem(string *int8) Bool {
+// llgo:link (*JSON).HasObjectItem C.cJSON_HasObjectItem
+func (recv_ *JSON) HasObjectItem(string *int8) CustomBool {
 	return 0
 }
 //go:linkname GetErrorPtr C.cJSON_GetErrorPtr
 func GetErrorPtr() *int8
-// llgo:link (*CJSON).GetStringValue C.cJSON_GetStringValue
-func (recv_ *CJSON) GetStringValue() *int8 {
+// llgo:link (*JSON).GetStringValue C.cJSON_GetStringValue
+func (recv_ *JSON) GetStringValue() *int8 {
 	return nil
 }
-// llgo:link (*CJSON).GetNumberValue C.cJSON_GetNumberValue
-func (recv_ *CJSON) GetNumberValue() float64 {
+// llgo:link (*JSON).GetNumberValue C.cJSON_GetNumberValue
+func (recv_ *JSON) GetNumberValue() float64 {
 	return 0
 }
-// llgo:link (*CJSON).IsInvalid C.cJSON_IsInvalid
-func (recv_ *CJSON) IsInvalid() Bool {
+// llgo:link (*JSON).IsInvalid C.cJSON_IsInvalid
+func (recv_ *JSON) IsInvalid() CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).IsFalse C.cJSON_IsFalse
-func (recv_ *CJSON) IsFalse() Bool {
+// llgo:link (*JSON).IsFalse C.cJSON_IsFalse
+func (recv_ *JSON) IsFalse() CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).IsTrue C.cJSON_IsTrue
-func (recv_ *CJSON) IsTrue() Bool {
+// llgo:link (*JSON).IsTrue C.cJSON_IsTrue
+func (recv_ *JSON) IsTrue() CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).IsBool C.cJSON_IsBool
-func (recv_ *CJSON) IsBool() Bool {
+// llgo:link (*JSON).IsBool C.cJSON_IsBool
+func (recv_ *JSON) IsBool() CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).IsNull C.cJSON_IsNull
-func (recv_ *CJSON) IsNull() Bool {
+// llgo:link (*JSON).IsNull C.cJSON_IsNull
+func (recv_ *JSON) IsNull() CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).IsNumber C.cJSON_IsNumber
-func (recv_ *CJSON) IsNumber() Bool {
+// llgo:link (*JSON).IsNumber C.cJSON_IsNumber
+func (recv_ *JSON) IsNumber() CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).IsString C.cJSON_IsString
-func (recv_ *CJSON) IsString() Bool {
+// llgo:link (*JSON).IsString C.cJSON_IsString
+func (recv_ *JSON) IsString() CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).IsArray C.cJSON_IsArray
-func (recv_ *CJSON) IsArray() Bool {
+// llgo:link (*JSON).IsArray C.cJSON_IsArray
+func (recv_ *JSON) IsArray() CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).IsObject C.cJSON_IsObject
-func (recv_ *CJSON) IsObject() Bool {
+// llgo:link (*JSON).IsObject C.cJSON_IsObject
+func (recv_ *JSON) IsObject() CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).IsRaw C.cJSON_IsRaw
-func (recv_ *CJSON) IsRaw() Bool {
+// llgo:link (*JSON).IsRaw C.cJSON_IsRaw
+func (recv_ *JSON) IsRaw() CustomBool {
 	return 0
 }
 //go:linkname CreateNull C.cJSON_CreateNull
-func CreateNull() *CJSON
+func CreateNull() *JSON
 //go:linkname CreateTrue C.cJSON_CreateTrue
-func CreateTrue() *CJSON
+func CreateTrue() *JSON
 //go:linkname CreateFalse C.cJSON_CreateFalse
-func CreateFalse() *CJSON
-// llgo:link (Bool).CreateBool C.cJSON_CreateBool
-func (recv_ Bool) CreateBool() *CJSON {
+func CreateFalse() *JSON
+// llgo:link CustomBool.CreateBool C.cJSON_CreateBool
+func (recv_ CustomBool) CreateBool() *JSON {
 	return nil
 }
 //go:linkname CreateNumber C.cJSON_CreateNumber
-func CreateNumber(num float64) *CJSON
+func CreateNumber(num float64) *JSON
 //go:linkname CreateString C.cJSON_CreateString
-func CreateString(string *int8) *CJSON
+func CreateString(string *int8) *JSON
 //go:linkname CreateRaw C.cJSON_CreateRaw
-func CreateRaw(raw *int8) *CJSON
+func CreateRaw(raw *int8) *JSON
 //go:linkname CreateArray C.cJSON_CreateArray
-func CreateArray() *CJSON
+func CreateArray() *JSON
 //go:linkname CreateObject C.cJSON_CreateObject
-func CreateObject() *CJSON
+func CreateObject() *JSON
 //go:linkname CreateStringReference C.cJSON_CreateStringReference
-func CreateStringReference(string *int8) *CJSON
-// llgo:link (*CJSON).CreateObjectReference C.cJSON_CreateObjectReference
-func (recv_ *CJSON) CreateObjectReference() *CJSON {
+func CreateStringReference(string *int8) *JSON
+// llgo:link (*JSON).CreateObjectReference C.cJSON_CreateObjectReference
+func (recv_ *JSON) CreateObjectReference() *JSON {
 	return nil
 }
-// llgo:link (*CJSON).CreateArrayReference C.cJSON_CreateArrayReference
-func (recv_ *CJSON) CreateArrayReference() *CJSON {
+// llgo:link (*JSON).CreateArrayReference C.cJSON_CreateArrayReference
+func (recv_ *JSON) CreateArrayReference() *JSON {
 	return nil
 }
 //go:linkname CreateIntArray C.cJSON_CreateIntArray
-func CreateIntArray(numbers *c.Int, count c.Int) *CJSON
+func CreateIntArray(numbers *c.Int, count c.Int) *JSON
 //go:linkname CreateFloatArray C.cJSON_CreateFloatArray
-func CreateFloatArray(numbers *float32, count c.Int) *CJSON
+func CreateFloatArray(numbers *float32, count c.Int) *JSON
 //go:linkname CreateDoubleArray C.cJSON_CreateDoubleArray
-func CreateDoubleArray(numbers *float64, count c.Int) *CJSON
+func CreateDoubleArray(numbers *float64, count c.Int) *JSON
 //go:linkname CreateStringArray C.cJSON_CreateStringArray
-func CreateStringArray(strings **int8, count c.Int) *CJSON
-// llgo:link (*CJSON).AddItemToArray C.cJSON_AddItemToArray
-func (recv_ *CJSON) AddItemToArray(item *CJSON) Bool {
+func CreateStringArray(strings **int8, count c.Int) *JSON
+// llgo:link (*JSON).AddItemToArray C.cJSON_AddItemToArray
+func (recv_ *JSON) AddItemToArray(item *JSON) CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).AddItemToObject C.cJSON_AddItemToObject
-func (recv_ *CJSON) AddItemToObject(string *int8, item *CJSON) Bool {
+// llgo:link (*JSON).AddItemToObject C.cJSON_AddItemToObject
+func (recv_ *JSON) AddItemToObject(string *int8, item *JSON) CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).AddItemToObjectCS C.cJSON_AddItemToObjectCS
-func (recv_ *CJSON) AddItemToObjectCS(string *int8, item *CJSON) Bool {
+// llgo:link (*JSON).AddItemToObjectCS C.cJSON_AddItemToObjectCS
+func (recv_ *JSON) AddItemToObjectCS(string *int8, item *JSON) CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).AddItemReferenceToArray C.cJSON_AddItemReferenceToArray
-func (recv_ *CJSON) AddItemReferenceToArray(item *CJSON) Bool {
+// llgo:link (*JSON).AddItemReferenceToArray C.cJSON_AddItemReferenceToArray
+func (recv_ *JSON) AddItemReferenceToArray(item *JSON) CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).AddItemReferenceToObject C.cJSON_AddItemReferenceToObject
-func (recv_ *CJSON) AddItemReferenceToObject(string *int8, item *CJSON) Bool {
+// llgo:link (*JSON).AddItemReferenceToObject C.cJSON_AddItemReferenceToObject
+func (recv_ *JSON) AddItemReferenceToObject(string *int8, item *JSON) CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).DetachItemViaPointer C.cJSON_DetachItemViaPointer
-func (recv_ *CJSON) DetachItemViaPointer(item *CJSON) *CJSON {
+// llgo:link (*JSON).DetachItemViaPointer C.cJSON_DetachItemViaPointer
+func (recv_ *JSON) DetachItemViaPointer(item *JSON) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).DetachItemFromArray C.cJSON_DetachItemFromArray
-func (recv_ *CJSON) DetachItemFromArray(which c.Int) *CJSON {
+// llgo:link (*JSON).DetachItemFromArray C.cJSON_DetachItemFromArray
+func (recv_ *JSON) DetachItemFromArray(which c.Int) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).DeleteItemFromArray C.cJSON_DeleteItemFromArray
-func (recv_ *CJSON) DeleteItemFromArray(which c.Int) {
+// llgo:link (*JSON).DeleteItemFromArray C.cJSON_DeleteItemFromArray
+func (recv_ *JSON) DeleteItemFromArray(which c.Int) {
 }
-// llgo:link (*CJSON).DetachItemFromObject C.cJSON_DetachItemFromObject
-func (recv_ *CJSON) DetachItemFromObject(string *int8) *CJSON {
+// llgo:link (*JSON).DetachItemFromObject C.cJSON_DetachItemFromObject
+func (recv_ *JSON) DetachItemFromObject(string *int8) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).DetachItemFromObjectCaseSensitive C.cJSON_DetachItemFromObjectCaseSensitive
-func (recv_ *CJSON) DetachItemFromObjectCaseSensitive(string *int8) *CJSON {
+// llgo:link (*JSON).DetachItemFromObjectCaseSensitive C.cJSON_DetachItemFromObjectCaseSensitive
+func (recv_ *JSON) DetachItemFromObjectCaseSensitive(string *int8) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).DeleteItemFromObject C.cJSON_DeleteItemFromObject
-func (recv_ *CJSON) DeleteItemFromObject(string *int8) {
+// llgo:link (*JSON).DeleteItemFromObject C.cJSON_DeleteItemFromObject
+func (recv_ *JSON) DeleteItemFromObject(string *int8) {
 }
-// llgo:link (*CJSON).DeleteItemFromObjectCaseSensitive C.cJSON_DeleteItemFromObjectCaseSensitive
-func (recv_ *CJSON) DeleteItemFromObjectCaseSensitive(string *int8) {
+// llgo:link (*JSON).DeleteItemFromObjectCaseSensitive C.cJSON_DeleteItemFromObjectCaseSensitive
+func (recv_ *JSON) DeleteItemFromObjectCaseSensitive(string *int8) {
 }
-// llgo:link (*CJSON).InsertItemInArray C.cJSON_InsertItemInArray
-func (recv_ *CJSON) InsertItemInArray(which c.Int, newitem *CJSON) Bool {
+// llgo:link (*JSON).InsertItemInArray C.cJSON_InsertItemInArray
+func (recv_ *JSON) InsertItemInArray(which c.Int, newitem *JSON) CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).ReplaceItemViaPointer C.cJSON_ReplaceItemViaPointer
-func (recv_ *CJSON) ReplaceItemViaPointer(item *CJSON, replacement *CJSON) Bool {
+// llgo:link (*JSON).ReplaceItemViaPointer C.cJSON_ReplaceItemViaPointer
+func (recv_ *JSON) ReplaceItemViaPointer(item *JSON, replacement *JSON) CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).ReplaceItemInArray C.cJSON_ReplaceItemInArray
-func (recv_ *CJSON) ReplaceItemInArray(which c.Int, newitem *CJSON) Bool {
+// llgo:link (*JSON).ReplaceItemInArray C.cJSON_ReplaceItemInArray
+func (recv_ *JSON) ReplaceItemInArray(which c.Int, newitem *JSON) CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).ReplaceItemInObject C.cJSON_ReplaceItemInObject
-func (recv_ *CJSON) ReplaceItemInObject(string *int8, newitem *CJSON) Bool {
+// llgo:link (*JSON).ReplaceItemInObject C.cJSON_ReplaceItemInObject
+func (recv_ *JSON) ReplaceItemInObject(string *int8, newitem *JSON) CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).ReplaceItemInObjectCaseSensitive C.cJSON_ReplaceItemInObjectCaseSensitive
-func (recv_ *CJSON) ReplaceItemInObjectCaseSensitive(string *int8, newitem *CJSON) Bool {
+// llgo:link (*JSON).ReplaceItemInObjectCaseSensitive C.cJSON_ReplaceItemInObjectCaseSensitive
+func (recv_ *JSON) ReplaceItemInObjectCaseSensitive(string *int8, newitem *JSON) CustomBool {
 	return 0
 }
-// llgo:link (*CJSON).Duplicate C.cJSON_Duplicate
-func (recv_ *CJSON) Duplicate(recurse Bool) *CJSON {
+// llgo:link (*JSON).Duplicate C.cJSON_Duplicate
+func (recv_ *JSON) Duplicate(recurse CustomBool) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).Compare C.cJSON_Compare
-func (recv_ *CJSON) Compare(b *CJSON, case_sensitive Bool) Bool {
+// llgo:link (*JSON).Compare C.cJSON_Compare
+func (recv_ *JSON) Compare(b *JSON, case_sensitive CustomBool) CustomBool {
 	return 0
 }
 //go:linkname Minify C.cJSON_Minify
 func Minify(json *int8)
-// llgo:link (*CJSON).AddNullToObject C.cJSON_AddNullToObject
-func (recv_ *CJSON) AddNullToObject(name *int8) *CJSON {
+// llgo:link (*JSON).AddNullToObject C.cJSON_AddNullToObject
+func (recv_ *JSON) AddNullToObject(name *int8) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).AddTrueToObject C.cJSON_AddTrueToObject
-func (recv_ *CJSON) AddTrueToObject(name *int8) *CJSON {
+// llgo:link (*JSON).AddTrueToObject C.cJSON_AddTrueToObject
+func (recv_ *JSON) AddTrueToObject(name *int8) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).AddFalseToObject C.cJSON_AddFalseToObject
-func (recv_ *CJSON) AddFalseToObject(name *int8) *CJSON {
+// llgo:link (*JSON).AddFalseToObject C.cJSON_AddFalseToObject
+func (recv_ *JSON) AddFalseToObject(name *int8) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).AddBoolToObject C.cJSON_AddBoolToObject
-func (recv_ *CJSON) AddBoolToObject(name *int8, boolean Bool) *CJSON {
+// llgo:link (*JSON).AddBoolToObject C.cJSON_AddBoolToObject
+func (recv_ *JSON) AddBoolToObject(name *int8, boolean CustomBool) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).AddNumberToObject C.cJSON_AddNumberToObject
-func (recv_ *CJSON) AddNumberToObject(name *int8, number float64) *CJSON {
+// llgo:link (*JSON).AddNumberToObject C.cJSON_AddNumberToObject
+func (recv_ *JSON) AddNumberToObject(name *int8, number float64) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).AddStringToObject C.cJSON_AddStringToObject
-func (recv_ *CJSON) AddStringToObject(name *int8, string *int8) *CJSON {
+// llgo:link (*JSON).AddStringToObject C.cJSON_AddStringToObject
+func (recv_ *JSON) AddStringToObject(name *int8, string *int8) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).AddRawToObject C.cJSON_AddRawToObject
-func (recv_ *CJSON) AddRawToObject(name *int8, raw *int8) *CJSON {
+// llgo:link (*JSON).AddRawToObject C.cJSON_AddRawToObject
+func (recv_ *JSON) AddRawToObject(name *int8, raw *int8) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).AddObjectToObject C.cJSON_AddObjectToObject
-func (recv_ *CJSON) AddObjectToObject(name *int8) *CJSON {
+// llgo:link (*JSON).AddObjectToObject C.cJSON_AddObjectToObject
+func (recv_ *JSON) AddObjectToObject(name *int8) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).AddArrayToObject C.cJSON_AddArrayToObject
-func (recv_ *CJSON) AddArrayToObject(name *int8) *CJSON {
+// llgo:link (*JSON).AddArrayToObject C.cJSON_AddArrayToObject
+func (recv_ *JSON) AddArrayToObject(name *int8) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).SetNumberHelper C.cJSON_SetNumberHelper
-func (recv_ *CJSON) SetNumberHelper(number float64) float64 {
+// llgo:link (*JSON).SetNumberHelper C.cJSON_SetNumberHelper
+func (recv_ *JSON) SetNumberHelper(number float64) float64 {
 	return 0
 }
-// llgo:link (*CJSON).SetValuestring C.cJSON_SetValuestring
-func (recv_ *CJSON) SetValuestring(valuestring *int8) *int8 {
+// llgo:link (*JSON).SetValuestring C.cJSON_SetValuestring
+func (recv_ *JSON) SetValuestring(valuestring *int8) *int8 {
 	return nil
 }
 //go:linkname Malloc C.cJSON_malloc
@@ -293,61 +293,61 @@ import (
 	"github.com/goplus/llgo/c"
 	_ "unsafe"
 )
-// llgo:link (*CJSON).GetPointer C.cJSONUtils_GetPointer
-func (recv_ *CJSON) GetPointer(pointer *int8) *CJSON {
+// llgo:link (*JSON).GetPointer C.cJSONUtils_GetPointer
+func (recv_ *JSON) GetPointer(pointer *int8) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).GetPointerCaseSensitive C.cJSONUtils_GetPointerCaseSensitive
-func (recv_ *CJSON) GetPointerCaseSensitive(pointer *int8) *CJSON {
+// llgo:link (*JSON).GetPointerCaseSensitive C.cJSONUtils_GetPointerCaseSensitive
+func (recv_ *JSON) GetPointerCaseSensitive(pointer *int8) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).GeneratePatches C.cJSONUtils_GeneratePatches
-func (recv_ *CJSON) GeneratePatches(to *CJSON) *CJSON {
+// llgo:link (*JSON).GeneratePatches C.cJSONUtils_GeneratePatches
+func (recv_ *JSON) GeneratePatches(to *JSON) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).GeneratePatchesCaseSensitive C.cJSONUtils_GeneratePatchesCaseSensitive
-func (recv_ *CJSON) GeneratePatchesCaseSensitive(to *CJSON) *CJSON {
+// llgo:link (*JSON).GeneratePatchesCaseSensitive C.cJSONUtils_GeneratePatchesCaseSensitive
+func (recv_ *JSON) GeneratePatchesCaseSensitive(to *JSON) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).AddPatchToArray C.cJSONUtils_AddPatchToArray
-func (recv_ *CJSON) AddPatchToArray(operation *int8, path *int8, value *CJSON) {
+// llgo:link (*JSON).AddPatchToArray C.cJSONUtils_AddPatchToArray
+func (recv_ *JSON) AddPatchToArray(operation *int8, path *int8, value *JSON) {
 }
-// llgo:link (*CJSON).ApplyPatches C.cJSONUtils_ApplyPatches
-func (recv_ *CJSON) ApplyPatches(patches *CJSON) c.Int {
+// llgo:link (*JSON).ApplyPatches C.cJSONUtils_ApplyPatches
+func (recv_ *JSON) ApplyPatches(patches *JSON) c.Int {
 	return 0
 }
-// llgo:link (*CJSON).ApplyPatchesCaseSensitive C.cJSONUtils_ApplyPatchesCaseSensitive
-func (recv_ *CJSON) ApplyPatchesCaseSensitive(patches *CJSON) c.Int {
+// llgo:link (*JSON).ApplyPatchesCaseSensitive C.cJSONUtils_ApplyPatchesCaseSensitive
+func (recv_ *JSON) ApplyPatchesCaseSensitive(patches *JSON) c.Int {
 	return 0
 }
-// llgo:link (*CJSON).MergePatch C.cJSONUtils_MergePatch
-func (recv_ *CJSON) MergePatch(patch *CJSON) *CJSON {
+// llgo:link (*JSON).MergePatch C.cJSONUtils_MergePatch
+func (recv_ *JSON) MergePatch(patch *JSON) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).MergePatchCaseSensitive C.cJSONUtils_MergePatchCaseSensitive
-func (recv_ *CJSON) MergePatchCaseSensitive(patch *CJSON) *CJSON {
+// llgo:link (*JSON).MergePatchCaseSensitive C.cJSONUtils_MergePatchCaseSensitive
+func (recv_ *JSON) MergePatchCaseSensitive(patch *JSON) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).GenerateMergePatch C.cJSONUtils_GenerateMergePatch
-func (recv_ *CJSON) GenerateMergePatch(to *CJSON) *CJSON {
+// llgo:link (*JSON).GenerateMergePatch C.cJSONUtils_GenerateMergePatch
+func (recv_ *JSON) GenerateMergePatch(to *JSON) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).GenerateMergePatchCaseSensitive C.cJSONUtils_GenerateMergePatchCaseSensitive
-func (recv_ *CJSON) GenerateMergePatchCaseSensitive(to *CJSON) *CJSON {
+// llgo:link (*JSON).GenerateMergePatchCaseSensitive C.cJSONUtils_GenerateMergePatchCaseSensitive
+func (recv_ *JSON) GenerateMergePatchCaseSensitive(to *JSON) *JSON {
 	return nil
 }
-// llgo:link (*CJSON).FindPointerFromObjectTo C.cJSONUtils_FindPointerFromObjectTo
-func (recv_ *CJSON) FindPointerFromObjectTo(target *CJSON) *int8 {
+// llgo:link (*JSON).FindPointerFromObjectTo C.cJSONUtils_FindPointerFromObjectTo
+func (recv_ *JSON) FindPointerFromObjectTo(target *JSON) *int8 {
 	return nil
 }
-// llgo:link (*CJSON).SortObject C.cJSONUtils_SortObject
-func (recv_ *CJSON) SortObject() {
+// llgo:link (*JSON).SortObject C.cJSONUtils_SortObject
+func (recv_ *JSON) SortObject() {
 }
-// llgo:link (*CJSON).SortObjectCaseSensitive C.cJSONUtils_SortObjectCaseSensitive
-func (recv_ *CJSON) SortObjectCaseSensitive() {
+// llgo:link (*JSON).SortObjectCaseSensitive C.cJSONUtils_SortObjectCaseSensitive
+func (recv_ *JSON) SortObjectCaseSensitive() {
 }
 
 ===== llcppg.pub =====
-cJSON CJSON
+cJSON JSON
 cJSON_Hooks Hooks
-cJSON_bool Bool
+cJSON_bool CustomBool

--- a/cmd/gogensig/convert/_testdata/receiver/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/receiver/gogensig.expect
@@ -29,7 +29,7 @@ type AresAddr struct {
 }
 //go:linkname AresDnsPton C.ares_dns_pton
 func AresDnsPton(ipaddr *int8, addr *AresAddr) unsafe.Pointer
-// llgo:link (*aresAddr).AresDnsAddrToPtr C.ares_dns_addr_to_ptr
+// llgo:link (*AresAddr).AresDnsAddrToPtr C.ares_dns_addr_to_ptr
 func (recv_ *AresAddr) AresDnsAddrToPtr() *int8 {
 	return nil
 }

--- a/cmd/gogensig/convert/funcname.go
+++ b/cmd/gogensig/convert/funcname.go
@@ -6,6 +6,7 @@ type GoFuncName struct {
 	goSymbolName string
 	recvName     string
 	funcName     string
+	ptrRecv      bool // if the receiver is a pointer
 }
 
 func NewGoFuncName(name string) *GoFuncName {
@@ -13,7 +14,14 @@ func NewGoFuncName(name string) *GoFuncName {
 	if len(l) < 2 {
 		return &GoFuncName{goSymbolName: name, funcName: name}
 	}
-	return &GoFuncName{goSymbolName: name, recvName: l[0], funcName: l[1]}
+	recvName := l[0]
+	ptrRecv := false
+	if strings.HasPrefix(recvName, "(*") {
+		ptrRecv = true
+		recvName = strings.TrimPrefix(recvName, "(*")
+		recvName = strings.TrimSuffix(recvName, ")")
+	}
+	return &GoFuncName{goSymbolName: name, recvName: recvName, funcName: l[1], ptrRecv: ptrRecv}
 }
 
 func (p *GoFuncName) HasReceiver() bool {

--- a/cmd/gogensig/convert/package_bulitin_test.go
+++ b/cmd/gogensig/convert/package_bulitin_test.go
@@ -1,6 +1,7 @@
 package convert
 
 import (
+	"go/types"
 	"testing"
 
 	"github.com/goplus/gogen"
@@ -53,4 +54,26 @@ func TestTypeRefIncompleteFail(t *testing.T) {
 			X: &ast.Ident{Name: "Bar"},
 		},
 	}, nil)
+}
+
+func TestPubMethodName(t *testing.T) {
+	name := types.NewTypeName(0, nil, "Foo", nil)
+	named := types.NewNamed(name, nil, nil)
+	ptrRecv := types.NewPointer(named)
+	fnName := "Foo"
+	pubName := pubMethodName(ptrRecv, fnName)
+	if pubName != "(*Foo).Foo" {
+		t.Fatal("Expected pubName to be '(*Foo).Foo', got", pubName)
+	}
+	valRecv := named
+	pubName = pubMethodName(valRecv, fnName)
+	if pubName != "Foo.Foo" {
+		t.Fatal("Expected pubName to be 'Foo.Foo', got", pubName)
+	}
+
+	unknownRecv := types.NewStruct(nil, []string{})
+	pubName = pubMethodName(unknownRecv, fnName)
+	if pubName != fnName {
+		t.Fatal("Expected pubName to be 'Foo', got", pubName)
+	}
 }

--- a/cmd/gogensig/convert/type.go
+++ b/cmd/gogensig/convert/type.go
@@ -414,15 +414,15 @@ func (p *TypeConv) referSysType(name string) (types.Object, error) {
 	return nil, nil
 }
 
-func (p *TypeConv) LookupSymbol(mangleName config.MangleNameType) (config.GoNameType, error) {
+func (p *TypeConv) LookupSymbol(mangleName config.MangleNameType) (*GoFuncSpec, error) {
 	if p.symbolTable == nil {
-		return "", fmt.Errorf("symbol table not initialized")
+		return nil, fmt.Errorf("symbol table not initialized")
 	}
 	e, err := p.symbolTable.LookupSymbol(mangleName)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return e.GoName, nil
+	return NewGoFuncSpec(e.GoName), nil
 }
 
 // The field name should be public if it's a record field


### PR DESCRIPTION
fix #108 

* 现在的llgo:link 中的receiver的名字直接从函数签名中获取，即不会出现llgo:link 的 recevier 与函数签名的receiver不一致的情况