### PR TITLE
llcppsymg:cache file in translation unit

### DIFF
--- a/_xtool/llcppsymg/_cmptest/parse_test/parse.go
+++ b/_xtool/llcppsymg/_cmptest/parse_test/parse.go
@@ -157,7 +157,7 @@ int(lua_sizecomp)(size_t s, int idx1, int idx2, int op);
 	for _, tc := range testCases {
 		fmt.Printf("=== Test Case: %s ===\n", tc.name)
 
-		symbolMap, err := parse.ParseHeaderFile([]string{tc.content}, tc.prefixes, tc.isCpp, true)
+		symbolMap, err := parse.ParseHeaderFile([]string{tc.content}, tc.prefixes, []string{}, tc.isCpp, true)
 
 		if err != nil {
 			fmt.Printf("Error: %v\n", err)

--- a/_xtool/llcppsymg/_cmptest/symg_test/cjson/cJSON.h
+++ b/_xtool/llcppsymg/_cmptest/symg_test/cjson/cJSON.h
@@ -1,0 +1,28 @@
+#define CJSON_PUBLIC(type) type
+#include <stddef.h>
+/* The cJSON structure: */
+typedef struct cJSON {
+    /* next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem */
+    struct cJSON *next;
+    struct cJSON *prev;
+    /* An array or object item will have a child pointer pointing to a chain of the items in the array/object. */
+    struct cJSON *child;
+
+    /* The type of the item, as above. */
+    int type;
+
+    /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
+    char *valuestring;
+    /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
+    int valueint;
+    /* The item's number, if type==cJSON_Number */
+    double valuedouble;
+
+    /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
+    char *string;
+} cJSON;
+/* Render a cJSON entity to text for transfer/storage. */
+CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item);
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLength(const char *value, size_t buffer_length);
+/* Delete a cJSON entity and all subentities. */
+CJSON_PUBLIC(void) cJSON_Delete(cJSON *item);

--- a/_xtool/llcppsymg/_cmptest/symg_test/cjson/llcppg.cfg
+++ b/_xtool/llcppsymg/_cmptest/symg_test/cjson/llcppg.cfg
@@ -1,0 +1,8 @@
+{
+	"name": "cjson",
+	"include": [
+		"cJSON.h"
+	],
+	"trimPrefixes": ["cJSON_"],
+	"cplusplus": false
+}

--- a/_xtool/llcppsymg/_cmptest/symg_test/inireader/INIReader.h
+++ b/_xtool/llcppsymg/_cmptest/symg_test/inireader/INIReader.h
@@ -1,0 +1,14 @@
+#define INI_API __attribute__((visibility("default")))
+class INIReader
+{
+public:
+    __attribute__((visibility("default"))) explicit INIReader(const char *filename);
+    INI_API explicit INIReader(const char *buffer, long buffer_size);
+    ~INIReader();
+    INI_API int ParseError() const;
+    INI_API const char *Get(const char *section, const char *name,
+                            const char *default_value) const;
+
+private:
+    static const char *MakeKey(const char *section, const char *name);
+};

--- a/_xtool/llcppsymg/_cmptest/symg_test/inireader/llcppg.cfg
+++ b/_xtool/llcppsymg/_cmptest/symg_test/inireader/llcppg.cfg
@@ -1,0 +1,8 @@
+{
+	"name": "inireader",
+	"include": [
+		"INIReader.h"
+	],
+	"trimPrefixes": ["INI"],
+	"cplusplus": true
+}

--- a/_xtool/llcppsymg/_cmptest/symg_test/inireader/llcppg.symb.json
+++ b/_xtool/llcppsymg/_cmptest/symg_test/inireader/llcppg.symb.json
@@ -1,0 +1,22 @@
+[
+  {
+    "mangle": "_ZN9INIReaderC1EPKc",
+    "c++": "INIReader::INIReader(const char *)",
+    "go": "(*Reader).Init"
+  },
+  {
+    "mangle": "_ZN9INIReaderC1EPKcl",
+    "c++": "INIReader::INIReader(const char *, long)",
+    "go": "(*Reader).Init__1"
+  },
+  {
+    "mangle": "_ZN9INIReaderD1Ev",
+    "c++": "INIReader::~INIReader()",
+    "go": "(*Reader).Dispose"
+  },
+  {
+    "mangle": "_ZNK9INIReader10ParseErrorEv",
+    "c++": "INIReader::ParseError()",
+    "go": "(*Reader).ModifyedParseError"
+  }
+]

--- a/_xtool/llcppsymg/_cmptest/symg_test/isl/isl/ctx.h
+++ b/_xtool/llcppsymg/_cmptest/symg_test/isl/isl/ctx.h
@@ -1,0 +1,8 @@
+typedef struct isl_ctx isl_ctx;
+
+#ifndef __isl_keep
+#define __isl_keep
+#endif
+#ifndef __isl_export
+#define __isl_export
+#endif

--- a/_xtool/llcppsymg/_cmptest/symg_test/isl/isl/polynomial.h
+++ b/_xtool/llcppsymg/_cmptest/symg_test/isl/isl/polynomial.h
@@ -1,0 +1,3 @@
+#include <isl/polynomial_type.h>
+
+isl_ctx *isl_pw_qpolynomial_get_ctx(__isl_keep isl_pw_qpolynomial *pwqp);

--- a/_xtool/llcppsymg/_cmptest/symg_test/isl/isl/polynomial_type.h
+++ b/_xtool/llcppsymg/_cmptest/symg_test/isl/isl/polynomial_type.h
@@ -1,0 +1,3 @@
+#include <isl/ctx.h>
+struct __isl_export isl_pw_qpolynomial;
+typedef struct isl_pw_qpolynomial isl_pw_qpolynomial;

--- a/_xtool/llcppsymg/_cmptest/symg_test/isl/llcppg.cfg
+++ b/_xtool/llcppsymg/_cmptest/symg_test/isl/llcppg.cfg
@@ -1,0 +1,9 @@
+{
+	"name": "isl",
+	"include": [
+		"isl/polynomial.h",
+        "isl/polynomial_type.h",
+        "isl/ctx.h" 
+	],
+	"cplusplus": false
+}

--- a/_xtool/llcppsymg/_cmptest/symg_test/llgo.expect
+++ b/_xtool/llcppsymg/_cmptest/symg_test/llgo.expect
@@ -53,6 +53,12 @@
 		"c++":	"cJSON_Delete(cJSON *)",
 		"go":	"(*CJSON).Delete"
 	}]
+=== Test Case: isl ===
+[{
+		"mangle":	"isl_pw_qpolynomial_get_ctx",
+		"c++":	"isl_pw_qpolynomial_get_ctx(isl_pw_qpolynomial *)",
+		"go":	"(*IslPwQpolynomial).IslPwQpolynomialGetCtx"
+	}]
 
 #stderr
 

--- a/_xtool/llcppsymg/_cmptest/symg_test/llgo.expect
+++ b/_xtool/llcppsymg/_cmptest/symg_test/llgo.expect
@@ -39,6 +39,20 @@
 		"c++":	"lua_stringtonumber(lua_State *, const char *)",
 		"go":	"(*State).Stringtonumber"
 	}]
+=== Test Case: cjson ===
+[{
+		"mangle":	"cJSON_Print",
+		"c++":	"cJSON_Print(const cJSON *)",
+		"go":	"(*CJSON).Print"
+	}, {
+		"mangle":	"cJSON_ParseWithLength",
+		"c++":	"cJSON_ParseWithLength(const char *, size_t)",
+		"go":	"ParseWithLength"
+	}, {
+		"mangle":	"cJSON_Delete",
+		"c++":	"cJSON_Delete(cJSON *)",
+		"go":	"(*CJSON).Delete"
+	}]
 
 #stderr
 

--- a/_xtool/llcppsymg/_cmptest/symg_test/lua/llcppg.cfg
+++ b/_xtool/llcppsymg/_cmptest/symg_test/lua/llcppg.cfg
@@ -1,0 +1,8 @@
+{
+	"name": "lua",
+	"include": [
+		"lua.h"
+	],
+	"trimPrefixes": ["lua_"],
+	"cplusplus": false
+}

--- a/_xtool/llcppsymg/_cmptest/symg_test/lua/lua.h
+++ b/_xtool/llcppsymg/_cmptest/symg_test/lua/lua.h
@@ -1,0 +1,13 @@
+#include <stddef.h>
+
+typedef struct lua_State lua_State;
+
+typedef void *(*lua_Alloc)(void *ud, void *ptr, size_t osize, size_t nsize);
+int(lua_error)(lua_State *L);
+void(lua_concat)(lua_State *L, int n);
+int(lua_next)(lua_State *L, int idx);
+void(lua_len)(lua_State *L, int idx);
+long unsigned int(lua_stringtonumber)(lua_State *L, const char *s);
+void(lua_setallocf)(lua_State *L, lua_Alloc f, void *ud);
+void(lua_toclose)(lua_State *L, int idx);
+void(lua_closeslot)(lua_State *L, int idx);

--- a/_xtool/llcppsymg/_cmptest/symg_test/symg.go
+++ b/_xtool/llcppsymg/_cmptest/symg_test/symg.go
@@ -3,7 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
+	"github.com/goplus/llcppg/_xtool/llcppsymg/config"
 	"github.com/goplus/llcppg/_xtool/llcppsymg/parse"
 	"github.com/goplus/llcppg/_xtool/llcppsymg/symbol"
 	"github.com/goplus/llgo/xtool/nm"
@@ -14,144 +16,82 @@ func main() {
 }
 func TestParseHeaderFile() {
 	testCases := []struct {
-		name            string
-		content         string
-		isCpp           bool
-		prefixes        []string
-		dylibSymbols    []*nm.Symbol
-		symbFileContent string
+		name         string
+		path         string
+		dylibSymbols []string
 	}{
 		{
 			name: "inireader",
-			content: `
-#define INI_API __attribute__((visibility("default")))
-class INIReader {
-  public:
-    __attribute__((visibility("default"))) explicit INIReader(const char *filename);
-    INI_API explicit INIReader(const char *buffer, long buffer_size);
-    ~INIReader();
-    INI_API int ParseError() const;
-	INI_API const char * Get(const char *section, const char *name,
-						const char *default_value) const;
-  private:
-    static const char * MakeKey(const char *section, const char *name);
-};
-            `,
-			isCpp:    true,
-			prefixes: []string{"INI"},
-			dylibSymbols: []*nm.Symbol{
-				{Name: symbol.AddSymbolPrefixUnder("ZN9INIReaderC1EPKc", true)},
-				{Name: symbol.AddSymbolPrefixUnder("ZN9INIReaderC1EPKcl", true)},
-				{Name: symbol.AddSymbolPrefixUnder("ZN9INIReaderD1Ev", true)},
-				{Name: symbol.AddSymbolPrefixUnder("ZNK9INIReader10ParseErrorEv", true)},
-				{Name: symbol.AddSymbolPrefixUnder("ZNK9INIReader3GetEPKcS1_S1_", true)},
+			path: "./inireader",
+			dylibSymbols: []string{
+				"ZN9INIReaderC1EPKc",
+				"ZN9INIReaderC1EPKcl",
+				"ZN9INIReaderD1Ev",
+				"ZNK9INIReader10ParseErrorEv",
+				"ZNK9INIReader3GetEPKcS1_S1_",
 			},
-			symbFileContent: `
-[{
-		"mangle":       "_ZN9INIReaderC1EPKc",
-		"c++":  "INIReader::INIReader(const char *)",
-		"go":   "(*Reader).Init"
-}, {
-		"mangle":       "_ZN9INIReaderC1EPKcl",
-		"c++":  "INIReader::INIReader(const char *, long)",
-		"go":   "(*Reader).Init__1"
-}, {
-		"mangle":       "_ZN9INIReaderD1Ev",
-		"c++":  "INIReader::~INIReader()",
-		"go":   "(*Reader).Dispose"
-}, {
-		"mangle":       "_ZNK9INIReader10ParseErrorEv",
-		"c++":  "INIReader::ParseError()",
-		"go":   "(*Reader).ModifyedParseError"
-}]`,
 		},
 		{
 			name: "lua",
-			content: `
-typedef struct lua_State lua_State;
-
-LUA_API int(lua_error)(lua_State *L);
-
-LUA_API int(lua_next)(lua_State *L, int idx);
-
-LUA_API void(lua_concat)(lua_State *L, int n);
-LUA_API void(lua_len)(lua_State *L, int idx);
-
-LUA_API long unsigned int(lua_stringtonumber)(lua_State *L, const char *s);
-
-LUA_API void(lua_setallocf)(lua_State *L, lua_Alloc f, void *ud);
-
-LUA_API void(lua_toclose)(lua_State *L, int idx);
-LUA_API void(lua_closeslot)(lua_State *L, int idx);
-            `,
-			isCpp:    false,
-			prefixes: []string{"lua_"},
-			dylibSymbols: []*nm.Symbol{
-				{Name: symbol.AddSymbolPrefixUnder("lua_error", false)},
-				{Name: symbol.AddSymbolPrefixUnder("lua_next", false)},
-				{Name: symbol.AddSymbolPrefixUnder("lua_concat", false)},
-				{Name: symbol.AddSymbolPrefixUnder("lua_stringtonumber", false)},
+			path: "./lua",
+			dylibSymbols: []string{
+				"lua_error",
+				"lua_next",
+				"lua_concat",
+				"lua_stringtonumber",
 			},
 		},
 		{
 			name: "cjson",
-			content: `
-		#define CJSON_PUBLIC(type) type
-		#include <stddef.h>
-		/* The cJSON structure: */
-		typedef struct cJSON {
-		    /* next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem */
-		    struct cJSON *next;
-		    struct cJSON *prev;
-		    /* An array or object item will have a child pointer pointing to a chain of the items in the array/object. */
-		    struct cJSON *child;
-
-		    /* The type of the item, as above. */
-		    int type;
-
-		    /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
-		    char *valuestring;
-		    /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
-		    int valueint;
-		    /* The item's number, if type==cJSON_Number */
-		    double valuedouble;
-
-		    /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
-		    char *string;
-		} cJSON;
-		/* Render a cJSON entity to text for transfer/storage. */
-		CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item);
-		CJSON_PUBLIC(cJSON *) cJSON_ParseWithLength(const char *value, size_t buffer_length);
-		/* Delete a cJSON entity and all subentities. */
-		CJSON_PUBLIC(void) cJSON_Delete(cJSON *item);
-					`,
-			isCpp:    false,
-			prefixes: []string{"cJSON_"},
-			dylibSymbols: []*nm.Symbol{
-				{Name: symbol.AddSymbolPrefixUnder("cJSON_Print", false)},
-				{Name: symbol.AddSymbolPrefixUnder("cJSON_ParseWithLength", false)},
-				{Name: symbol.AddSymbolPrefixUnder("cJSON_Delete", false)},
+			path: "./cjson",
+			dylibSymbols: []string{
+				"cJSON_Print",
+				"cJSON_ParseWithLength",
+				"cJSON_Delete",
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		fmt.Printf("=== Test Case: %s ===\n", tc.name)
-		headerSymbolMap, err := parse.ParseHeaderFile([]string{tc.content}, tc.prefixes, tc.isCpp, true)
+		projPath, err := filepath.Abs(tc.path)
+		if err != nil {
+			fmt.Println("Get Abs Path Error:", err)
+		}
+		cfgdata, err := os.ReadFile(filepath.Join(projPath, "llcppg.cfg"))
+		if err != nil {
+			fmt.Println("Read Cfg File Error:", err)
+		}
+		cfg, err := config.GetConf(cfgdata)
+		if err != nil {
+			fmt.Println("Get Conf Error:", err)
+		}
+		if err != nil {
+			fmt.Println("Read Symb File Error:", err)
+		}
+		files := []string{}
+		for _, include := range cfg.Include {
+			files = append(files, filepath.Join(projPath, include))
+		}
+
+		headerSymbolMap, err := parse.ParseHeaderFile(files, cfg.TrimPrefixes, cfg.Cplusplus, false)
 		if err != nil {
 			fmt.Println("Error:", err)
 		}
-		tmpFile, err := os.CreateTemp("", "llcppg.symb.json")
 		if err != nil {
 			fmt.Printf("Failed to create temp file: %v\n", err)
 			return
 		}
-		tmpFile.Write([]byte(tc.symbFileContent))
-		symbolData, err := symbol.GenerateAndUpdateSymbolTable(tc.dylibSymbols, headerSymbolMap, tmpFile.Name())
+
+		// trim to nm symbols
+		var dylibsymbs []*nm.Symbol
+		for _, symb := range tc.dylibSymbols {
+			dylibsymbs = append(dylibsymbs, &nm.Symbol{Name: symbol.AddSymbolPrefixUnder(symb, cfg.Cplusplus)})
+		}
+		symbolData, err := symbol.GenerateAndUpdateSymbolTable(dylibsymbs, headerSymbolMap, filepath.Join(projPath, "llcppg.symb.json"))
 		if err != nil {
 			fmt.Println("Error:", err)
 		}
 		fmt.Println(string(symbolData))
-		os.Remove(tmpFile.Name())
 	}
 }

--- a/_xtool/llcppsymg/_cmptest/symg_test/symg.go
+++ b/_xtool/llcppsymg/_cmptest/symg_test/symg.go
@@ -74,7 +74,8 @@ func TestParseHeaderFile() {
 			files = append(files, filepath.Join(projPath, include))
 		}
 
-		headerSymbolMap, err := parse.ParseHeaderFile(files, cfg.TrimPrefixes, cfg.Cplusplus, false)
+		cflags := []string{"-I" + projPath}
+		headerSymbolMap, err := parse.ParseHeaderFile(files, cfg.TrimPrefixes, cflags, cfg.Cplusplus, false)
 		if err != nil {
 			fmt.Println("Error:", err)
 		}

--- a/_xtool/llcppsymg/_cmptest/symg_test/symg.go
+++ b/_xtool/llcppsymg/_cmptest/symg_test/symg.go
@@ -50,6 +50,13 @@ func TestParseHeaderFile() {
 				"cJSON_Delete",
 			},
 		},
+		{
+			name: "isl",
+			path: "./isl",
+			dylibSymbols: []string{
+				"isl_pw_qpolynomial_get_ctx",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/_xtool/llcppsymg/_cmptest/symg_test/symg.go
+++ b/_xtool/llcppsymg/_cmptest/symg_test/symg.go
@@ -93,6 +93,46 @@ LUA_API void(lua_closeslot)(lua_State *L, int idx);
 				{Name: symbol.AddSymbolPrefixUnder("lua_stringtonumber", false)},
 			},
 		},
+		{
+			name: "cjson",
+			content: `
+		#define CJSON_PUBLIC(type) type
+		#include <stddef.h>
+		/* The cJSON structure: */
+		typedef struct cJSON {
+		    /* next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem */
+		    struct cJSON *next;
+		    struct cJSON *prev;
+		    /* An array or object item will have a child pointer pointing to a chain of the items in the array/object. */
+		    struct cJSON *child;
+
+		    /* The type of the item, as above. */
+		    int type;
+
+		    /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
+		    char *valuestring;
+		    /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
+		    int valueint;
+		    /* The item's number, if type==cJSON_Number */
+		    double valuedouble;
+
+		    /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
+		    char *string;
+		} cJSON;
+		/* Render a cJSON entity to text for transfer/storage. */
+		CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item);
+		CJSON_PUBLIC(cJSON *) cJSON_ParseWithLength(const char *value, size_t buffer_length);
+		/* Delete a cJSON entity and all subentities. */
+		CJSON_PUBLIC(void) cJSON_Delete(cJSON *item);
+					`,
+			isCpp:    false,
+			prefixes: []string{"cJSON_"},
+			dylibSymbols: []*nm.Symbol{
+				{Name: symbol.AddSymbolPrefixUnder("cJSON_Print", false)},
+				{Name: symbol.AddSymbolPrefixUnder("cJSON_ParseWithLength", false)},
+				{Name: symbol.AddSymbolPrefixUnder("cJSON_Delete", false)},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/_xtool/llcppsymg/dbg/debug.go
+++ b/_xtool/llcppsymg/dbg/debug.go
@@ -7,7 +7,7 @@ var flags dbgFlags
 const (
 	DbgSymbol        dbgFlags = 1 << iota
 	DbgParseIsMethod          //print parse.go isMethod debug log info
-	DbgFlagAll       = DbgSymbol
+	DbgFlagAll       = DbgSymbol | DbgParseIsMethod
 )
 
 func SetDebugSymbol() {

--- a/_xtool/llcppsymg/llcppsymg.go
+++ b/_xtool/llcppsymg/llcppsymg.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/goplus/llcppg/_xtool/llcppsymg/args"
 	"github.com/goplus/llcppg/_xtool/llcppsymg/config"
@@ -83,7 +84,7 @@ func main() {
 		}
 	}
 
-	headerInfos, err := parse.ParseHeaderFile(filepaths, conf.TrimPrefixes, conf.Cplusplus, false)
+	headerInfos, err := parse.ParseHeaderFile(filepaths, conf.TrimPrefixes, strings.Fields(conf.CFlags), conf.Cplusplus, false)
 	check(err)
 
 	symbolData, err := symbol.GenerateAndUpdateSymbolTable(symbols, headerInfos, symbFile)

--- a/_xtool/llcppsymg/parse/parse.go
+++ b/_xtool/llcppsymg/parse/parse.go
@@ -10,7 +10,6 @@ import (
 	"github.com/goplus/llcppg/_xtool/llcppsymg/clangutils"
 	"github.com/goplus/llcppg/_xtool/llcppsymg/dbg"
 	"github.com/goplus/llcppg/_xtool/llcppsymg/names"
-	"github.com/goplus/llgo/c"
 	"github.com/goplus/llgo/c/clang"
 )
 
@@ -20,11 +19,14 @@ type SymbolInfo struct {
 }
 
 type SymbolProcessor struct {
-	Files       []string
-	Prefixes    []string
-	SymbolMap   map[string]*SymbolInfo
-	CurrentFile string
-	NameCounts  map[string]int
+	Files      []string
+	Prefixes   []string
+	SymbolMap  map[string]*SymbolInfo
+	NameCounts map[string]int
+	// for independent files,signal that the file has been processed
+	// will clean in a translation unit process end
+	processingFiles map[string]struct{}
+	processedFiles  map[string]struct{}
 }
 
 func panicSourceLocation(loc clang.SourceLocation, prefix string) {
@@ -37,21 +39,16 @@ func panicSourceLocation(loc clang.SourceLocation, prefix string) {
 
 func NewSymbolProcessor(Files []string, Prefixes []string) *SymbolProcessor {
 	return &SymbolProcessor{
-		Files:      Files,
-		Prefixes:   Prefixes,
-		SymbolMap:  make(map[string]*SymbolInfo),
-		NameCounts: make(map[string]int),
+		Files:           Files,
+		Prefixes:        Prefixes,
+		SymbolMap:       make(map[string]*SymbolInfo),
+		NameCounts:      make(map[string]int),
+		processedFiles:  make(map[string]struct{}),
+		processingFiles: make(map[string]struct{}),
 	}
-}
-
-func (p *SymbolProcessor) setCurrentFile(filename string) {
-	p.CurrentFile = filename
 }
 
 func (p *SymbolProcessor) isSelfFile(filename string) bool {
-	if filename == p.CurrentFile {
-		return true
-	}
 	for _, file := range p.Files {
 		if file == filename {
 			return true
@@ -227,6 +224,9 @@ func (p *SymbolProcessor) collectFuncInfo(cursor clang.Cursor) {
 	// On Linux, C++ symbols typically have one leading underscore
 	// On macOS, C++ symbols may have two leading underscores
 	// For consistency, we remove the first leading underscore on macOS
+	if dbg.GetDebugSymbol() {
+		fmt.Printf("collectFuncInfo: %s %s\n", clang.GoString(cursor.Mangling()), clang.GoString(cursor.String()))
+	}
 	symbolName := clang.GoString(cursor.Mangling())
 	if runtime.GOOS == "darwin" {
 		symbolName = strings.TrimPrefix(symbolName, "_")
@@ -238,46 +238,64 @@ func (p *SymbolProcessor) collectFuncInfo(cursor clang.Cursor) {
 }
 
 func (p *SymbolProcessor) visitTop(cursor, parent clang.Cursor) clang.ChildVisitResult {
+	filename := clang.GoString(cursor.Location().File().FileName())
+	if _, ok := p.processedFiles[filename]; ok {
+		return clang.ChildVisit_Continue
+	}
+	p.processingFiles[filename] = struct{}{}
 	switch cursor.Kind {
 	case clang.CursorNamespace, clang.CursorClassDecl:
 		clangutils.VisitChildren(cursor, p.visitTop)
 	case clang.CursorCXXMethod, clang.CursorFunctionDecl, clang.CursorConstructor, clang.CursorDestructor:
-		loc := cursor.Location()
-		file, _, _, _ := clangutils.GetLocation(loc)
-		filename := file.FileName()
-		defer filename.Dispose()
-
-		isCurrentFile := c.Strcmp(filename.CStr(), c.AllocaCStr(p.CurrentFile)) == 0
 		isPublicMethod := (cursor.CXXAccessSpecifier() == clang.CXXPublic) && cursor.Kind == clang.CursorCXXMethod || cursor.Kind == clang.CursorConstructor || cursor.Kind == clang.CursorDestructor
-
-		if isCurrentFile && (cursor.Kind == clang.CursorFunctionDecl || isPublicMethod) {
+		if p.isSelfFile(filename) && (cursor.Kind == clang.CursorFunctionDecl || isPublicMethod) {
 			p.collectFuncInfo(cursor)
 		}
 	}
 	return clang.ChildVisit_Continue
 }
 
+func (p *SymbolProcessor) collect(cfg *clangutils.Config) error {
+	filename := cfg.File
+	if cfg.Temp {
+		filename = clangutils.TEMP_FILE
+	}
+	if _, ok := p.processedFiles[filename]; ok {
+		if dbg.GetDebugParseIsMethod() {
+			fmt.Printf("%s has been processed: \n", filename)
+		}
+		return nil
+	}
+	_, unit, err := clangutils.CreateTranslationUnit(cfg)
+	if err != nil {
+		return errors.New("Unable to parse translation unit for file " + filename)
+	}
+	cursor := unit.Cursor()
+	if dbg.GetDebugSymbol() {
+		fmt.Printf("%s start collect \n", filename)
+	}
+	clangutils.VisitChildren(cursor, p.visitTop)
+	for filename := range p.processingFiles {
+		p.processedFiles[filename] = struct{}{}
+	}
+	p.processingFiles = make(map[string]struct{})
+	unit.Dispose()
+	return nil
+}
+
 func ParseHeaderFile(files []string, Prefixes []string, isCpp bool, isTemp bool) (map[string]*SymbolInfo, error) {
-	processer := NewSymbolProcessor(files, Prefixes)
 	index := clang.CreateIndex(0, 0)
+	if isTemp {
+		files = append(files, clangutils.TEMP_FILE)
+	}
+	processer := NewSymbolProcessor(files, Prefixes)
 	for _, file := range files {
-		_, unit, err := clangutils.CreateTranslationUnit(&clangutils.Config{
+		processer.collect(&clangutils.Config{
 			File:  file,
 			Temp:  isTemp,
 			IsCpp: isCpp,
 			Index: index,
 		})
-		if err != nil {
-			return nil, errors.New("Unable to parse translation unit for file " + file)
-		}
-		cursor := unit.Cursor()
-		if isTemp {
-			processer.setCurrentFile(clangutils.TEMP_FILE)
-		} else {
-			processer.setCurrentFile(file)
-		}
-		clangutils.VisitChildren(cursor, processer.visitTop)
-		unit.Dispose()
 	}
 	index.Dispose()
 	return processer.SymbolMap, nil


### PR DESCRIPTION
#113 

fix #109 

* 将整体的函数信息收集逻辑，从一个文件对应一个翻译单元，修改为与llcppsigfetch一致的缓存策略，即从对于一个 a.h 为入口的翻译单元，收集其本身的函数信息，并对其include的头文件的函数符合信息一并收集，即可解决目前为了识别某个类型定义时，头文件各自为翻译单元，导致类型信息缺失的问题。
* 修改整体输入测试为文件配置输入。

```json
{
	"name": "isl",
	"cflags": "$(pkg-config --cflags isl)",
	"libs": "$(pkg-config --libs isl)",
	"include": [
	    "isl/polynomial.h",
	    "isl/polynomial_type.h",
            "isl/ctx.h",
            "isl/set.h",
            "isl/may_type.h"
	],
    "trimPrefixes": ["isl_"], 
	"cplusplus": false
}
```
get 
```
// llgo:link (*PwQpolynomial).PwQpolynomialGetCtx C.isl_pw_qpolynomial_get_ctx
func (recv_ *PwQpolynomial) PwQpolynomialGetCtx() *Ctx {
	return nil
}
```