### PR TITLE
gogensig:handle nested typedef of incomplete types

### DIFF
--- a/cmd/gogensig/convert/_testdata/forwarddecl/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/gogensig.expect
@@ -109,13 +109,21 @@ type Context struct {
 // llgo:type C
 type Fts5ExtensionFunction func(*Fts5ExtensionApi, *Fts5Context, *Context, c.Int, **Value)
 
+type X_XmlParserCtxt struct {
+	Unused [8]uint8
+}
+type XmlParserCtxt X_XmlParserCtxt
+type HtmlParserCtxt XmlParserCtxt
+
 ===== llcppg.pub =====
 Fts5Context
 Fts5ExtensionApi
 Fts5PhraseIter
+_xmlParserCtxt X_XmlParserCtxt
 bar Bar
 foo Foo
 fts5_extension_function Fts5ExtensionFunction
+htmlParserCtxt HtmlParserCtxt
 lua_Debug Debug
 lua_State State
 sqlite3_context Context
@@ -125,3 +133,4 @@ sqlite3_pcache Pcache
 sqlite3_pcache_methods2 PcacheMethods2
 sqlite3_pcache_page PcachePage
 sqlite3_value Value
+xmlParserCtxt XmlParserCtxt

--- a/cmd/gogensig/convert/_testdata/forwarddecl/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/hfile/temp.h
@@ -84,3 +84,9 @@ struct Fts5PhraseIter {
     const unsigned char *a;
     const unsigned char *b;
 };
+
+struct _xmlParserCtxt;
+
+typedef struct _xmlParserCtxt xmlParserCtxt;
+
+typedef xmlParserCtxt htmlParserCtxt;

--- a/cmd/gogensig/convert/package_bulitin_test.go
+++ b/cmd/gogensig/convert/package_bulitin_test.go
@@ -53,7 +53,7 @@ func TestTypeRefIncompleteFail(t *testing.T) {
 		Name: &ast.ScopingExpr{
 			X: &ast.Ident{Name: "Bar"},
 		},
-	}, nil)
+	}, nil, "NewBar")
 }
 
 func TestPubMethodName(t *testing.T) {

--- a/cmd/gogensig/convert/package_bulitin_test.go
+++ b/cmd/gogensig/convert/package_bulitin_test.go
@@ -31,7 +31,7 @@ func TestTypeRefIncompleteFail(t *testing.T) {
 		IncPath: "Bar",
 		Path:    "Bar",
 	}
-	pkg.incomplete["Bar"] = &Incomplete{}
+	pkg.incompleteTypes.Add(&Incomplete{cname: "Bar"})
 	err := pkg.NewTypedefDecl(&ast.TypedefDecl{
 		Name: &ast.Ident{Name: "Foo"},
 		Type: &ast.TagExpr{
@@ -41,7 +41,7 @@ func TestTypeRefIncompleteFail(t *testing.T) {
 	if err != nil {
 		t.Fatal("NewTypedefDecl failed:", err)
 	}
-	delete(pkg.incomplete, "Bar")
+	pkg.incompleteTypes.Complete("Bar")
 
 	err = pkg.WritePkgFiles()
 	if err == nil {


### PR DESCRIPTION
fix https://github.com/goplus/llcppg/issues/146

The problem stems from typedef-ing an incomplete type. Here's the English explanation:
The issue comes from typedef-ing an incomplete type. For incomplete types, their placeholder type initialization occurs after the entire project's conversion is complete. When typedef-ing an incomplete type, direct initialization fails because the underlying type of the incomplete type doesn't exist yet, making it impossible to construct the typedef node.
To handle this, delayed loading was implemented for typedef nodes of incomplete types. However, the problem arises when typedef-ing a node that itself is a typedef of an incomplete type (like in the example code). Since this also requires delayed loading, the same issue occurs.

```c
struct _xmlParserCtxt;

typedef struct _xmlParserCtxt xmlParserCtxt;

typedef xmlParserCtxt htmlParserCtxt;
```