### PR TITLE
llcppsigfetch:use std header map to instead clang_Location_isInSystem

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -130,14 +130,14 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         # install demo's lib
-        sudo apt install liblua5.4-dev libsqlite3-dev libgmp-dev libgpg-error-dev zlib1g-dev -y
+        sudo apt install liblua5.4-dev libsqlite3-dev libgmp-dev libgpg-error-dev zlib1g-dev libisl-dev -y
         llcppgtest -demo ./_llcppgtest/cjson
         llcppgtest -demo ./_llcppgtest/lua
         llcppgtest -demo ./_llcppgtest/sqlite
         llcppgtest -demo ./_llcppgtest/gmp
         llcppgtest -demo ./_llcppgtest/gpgerror
         llcppgtest -demo ./_llcppgtest/zlib
-        
+        llcppgtest -demo ./_llcppgtest/isl
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5

--- a/_xtool/llcppsymg/_cmptest/clangutils_test/clangutils.go
+++ b/_xtool/llcppsymg/_cmptest/clangutils_test/clangutils.go
@@ -11,6 +11,7 @@ import (
 
 func main() {
 	TestClangUtil()
+	TestComposeIncludes()
 }
 
 func TestClangUtil() {
@@ -115,5 +116,43 @@ func TestClangUtil() {
 		}
 
 		fmt.Println()
+	}
+}
+
+func TestComposeIncludes() {
+	fmt.Println("=== Test ComposeIncludes ===")
+	testCases := []struct {
+		name  string
+		files []string
+	}{
+		{
+			name:  "One file",
+			files: []string{"file1.h"},
+		},
+		{
+			name:  "Two files",
+			files: []string{"file1.h", "file2.h"},
+		},
+		{
+			name:  "Empty files",
+			files: []string{},
+		},
+	}
+	for _, tc := range testCases {
+		outfile, err := os.CreateTemp("", "compose_*.h")
+		if err != nil {
+			panic(err)
+		}
+		err = clangutils.ComposeIncludes(tc.files, outfile.Name())
+		if err != nil {
+			panic(err)
+		}
+		content, err := os.ReadFile(outfile.Name())
+		if err != nil {
+			panic(err)
+		}
+		fmt.Println(string(content))
+		outfile.Close()
+		os.Remove(outfile.Name())
 	}
 }

--- a/_xtool/llcppsymg/_cmptest/clangutils_test/llgo.expect
+++ b/_xtool/llcppsymg/_cmptest/clangutils_test/llgo.expect
@@ -17,6 +17,13 @@ Namespace: TestNamespace
 Function/Method: namespaced_function
 Scoping parts: [TestNamespace namespaced_function]
 
+=== Test ComposeIncludes ===
+#include <file1.h>
+
+#include <file1.h>
+#include <file2.h>
+
+
 
 #stderr
 

--- a/_xtool/llcppsymg/clangutils/clangutils.go
+++ b/_xtool/llcppsymg/clangutils/clangutils.go
@@ -2,6 +2,7 @@ package clangutils
 
 import (
 	"errors"
+	"os"
 	"unsafe"
 
 	"github.com/goplus/llgo/c"
@@ -75,6 +76,17 @@ func CreateTranslationUnit(config *Config) (*clang.Index, *clang.TranslationUnit
 	}
 
 	return index, unit, nil
+}
+
+// ComposeIncludes create Include list
+// #include <file1.h>
+// #include <file2.h>
+func ComposeIncludes(files []string, outfile string) error {
+	var str string
+	for _, file := range files {
+		str += ("#include <" + file + ">\n")
+	}
+	return os.WriteFile(outfile, []byte(str), 0644)
 }
 
 func GetLocation(loc clang.SourceLocation) (file clang.File, line c.Uint, column c.Uint, offset c.Uint) {


### PR DESCRIPTION
fix https://github.com/goplus/llcppg/issues/174
### Issue
clang_Location_isInSystemHeader exhibits instability in system header detection:

- The API sometimes incorrectly identifies third-party library headers installed in /usr/include as system headers
- This unstable behavior makes it unreliable to distinguish between standard library headers (like stdio.h ) and third-party library headers (`like isl/polynomial.h` )

For example, when third-party libraries are installed via package managers into /usr/include , clang_Location_isInSystemHeader may produce inconsistent results in its classification.

```json
{
  "name": "isl",
  "cflags": "-I/usr/include",
  "libs": "-lisl -lgmp ",
  "include": [
    "isl/polynomial.h",
    "isl/polynomial_type.h",
    "isl/ctx.h",
    "isl/set.h",
    "isl/map_type.h"
  ],
  "trimPrefixes": ["isl_set_", "isl_ctx_", "isl_"],
  "cplusplus": false
}
```

### Solution
- Create standard header map by parsing temp header file
- Support both C standard library and POSIX headers 

### Implement
1. Standard Library Detection:
   - Create temp file with all standard headers
   - Parse with clang to get actual paths
   - Store paths in map as reference
2. Header Validation:
   - Check if header path exists in reference map