### PR TITLE
llcppg:cross platform & refactor deps design

### DIFF
--- a/design.md
+++ b/design.md
@@ -19,7 +19,9 @@ If `config-file` is not specified, a `llcppg.cfg` file is used in current direct
   ],
   "libs": "$(pkg-config --libs inireader)",
   "trimPrefixes": ["Ini", "INI"],
-  "cplusplus":true
+  "cplusplus":true,
+  "deps":["c","github.com/..../third"],
+  "mix":false 
 }
 ```
 
@@ -82,4 +84,155 @@ It fetches information of C/C++ symbols and print to stdout. Its format is as fo
 ```sh
 gogensig ast-file
 gogensig -  # read AST from stdin
+```
+
+## Header File Processing Basic Rules
+
+* llcppg only converts header files within the current package
+* Does not convert third-party package and standard library header files
+* For package header files, two types of mappings are generated during processing:
+  * Function mapping table `llcppg.symb.json`
+  * Type mapping table `llcppg.pub`
+
+## Dependency Processing
+
+1. The system scans each dependency package's llcppg.pub file to obtain type mappings.
+2. If the dependency package's llcppg.cfg also contains deps configuration, the system will recursively process these dependencies.
+3. Type mappings from all dependency packages are loaded and registered into the conversion project.
+When a header file in the current project references types from third-party packages, it directly searches within the current conversion project scope
+ * If a mapped type is found, it is referenced;
+ * Otherwise, the user is notified of the missing type and its source header file for conversion.
+
+### Dependency Package Structure
+Each dependency package follows a unified file organization structure (using xml2 as an example):
+* Converted Go source files
+1. HTMLtree.go (generated from HTMLtree.h)
+2. HTMLparser.go (generated from HTMLparser.h)
+* Configuration files
+1. llcppg.cfg (dependency information)
+2. llcppg.pub (type mapping information)
+
+### Example Project
+```json
+{
+  "name":"xslt",
+  "include": [
+    "libxslt/xslt.h",
+    "libxslt/security.h",
+    "libexslt/exsltconfig.h"
+  ],
+  "deps": [
+    "c",
+    "github.com/goplus/..../xml2",
+    "github.com/goplus/..../zlib"
+  ]
+}
+```
+In `libxslt/xslt.h`, there are dependencies on `libxml2`'s `xmlChar` and `xmlNodePtr`:
+```c
+#include <libxml/dict.h>
+#include <libxml/xmlerror.h>
+#include <libxml/xpath.h>
+xmlChar * xsltGetNsProp(xmlNodePtr node, const xmlChar *name, const xmlChar *nameSpace);
+```
+If `xmlChar` and `xmlNodePtr` mappings are not found, llcppg will notify the user of these missing types and indicate they are from `libxml2` header files.
+The corresponding notification would be:
+```bash
+xmlChar not found in `/path/to/libxml/dict.h`.
+xmlNodePtr not found in `/path/to/libxml/dict.h`.
+```
+### Type Mapping Examples
+
+Standard Library Type Mapping
+NOTE: "c" is an alias for "github.com/goplus/llgo/c"
+`github.com/goplus/llgo/c/llcppg.pub`
+```
+size_t SizeT
+intptr_t IntptrT
+FILE
+```
+XML2 Type Mapping From Expamle
+`github.com/goplus/..../xml2/llcppg.pub`
+```
+xml_doc XmlDoc
+```
+## File Generation Rules
+### Generated File Types
+* Interface header files: Each header file generates a corresponding .go file
+* Implementation files: All generated in a single libname_autogen.go file
+
+### Header File Classification
+
+1. Interface header files:
+* Header files explicitly declared in include
+2. Implementation header files:
+* Other header files in the same root directory as interface header files
+
+#### Example Explanation
+For example, the header file paths obtained after linking with Clang in the above example:
+```
+/opt/homebrew/Cellar/libxslt/1.1.42_1/include/libxslt/xslt.h
+/opt/homebrew/Cellar/libxslt/1.1.42_1/include/libxslt/security.h
+/opt/homebrew/Cellar/libxslt/1.1.42_1/include/libexslt/exsltconfig.h
+```
+The calculated common root directory is:
+```
+/opt/homebrew/Cellar/libxslt/1.1.42_1/include/
+```
+In `libxslt/xslt.h`, the following header files are referenced:
+```c
+#include <libxml/tree.h>
+#include "xsltexports.h"
+```
+The corresponding paths are:
+`libxml/tree.h` -> `/opt/homebrew/Cellar/libxml2/2.13.5/include/libxml2/libxml/tree.h` (third-party dependency)
+`xsltexports.h` -> `/opt/homebrew/Cellar/libxslt/1.1.42_1/include/libxslt/xsltexports.h` (package implementation file)
+Since `xsltexports.h` is in the same directory as `libxslt/xslt.h`, it's considered a package implementation file, and its content is generated in `xslt_autogen.go`. Meanwhile, `libxml/tree.h` is not in the same directory and is considered a third-party dependency.
+## Special Case Handling
+### System Path Processing
+For third-party header files mixed in system paths (common in Linux apt-installed libraries, e.g., `/usr/include/sqlite3.h` and `/usr/include/stdio.h`):
+1. Configuration method
+```json
+{
+  "mix": true
+}
+```
+2. Processing rules
+* Header files explicitly declared in include are considered package header files; all others are treated as third-party header files.
+
+### Cross-Platform Difference Handling
+Use impl.files configuration to handle platform differences:
+```json
+{
+    "impl": [
+        {
+            "files": ["t1.h", "t2.h"],
+            "cond": {
+                "os": ["macos", "linux"],
+                "arch": ["arm64", "amd64"]
+            }
+        }
+    ]
+}
+```
+The generated t1.go & t2.go files will have platform-specific build tags at the beginning:
+macos arm64 t1_macos_arm64.go  t2_macos_arm64.go
+```go
+// +build macos,arm64
+package xxx
+```
+linux arm64 `t1_linux_arm64.go`  `t2_linux_arm64.go`
+```go
+// +build linux,arm64
+package xxx
+```
+macos amd64  `t1_macos_amd64.go`  `t2_macos_amd64.go`
+```go
+// +build macos,amd64
+package xxx
+```
+linux amd64 `t1_linux_amd64.go`  `t2_linux_amd64.go`
+```go
+// +build linux,amd64
+package xxx
 ```


### PR DESCRIPTION
# Chinense version
---
## 1. 头文件处理基础规则
* llcppg 只转换本包内的头文件
* 不转换第三方包和标准库的头文件
* 对于本包头文件在处理过程中生成两类映射:
     *  函数映射表 llcppg.symb.json
     * 类型映射表  llcppg.pub
## 2. 依赖处理
1. 系统扫描每个依赖包的 llcppg.pub 文件以获取类型映射.
2. 如果依赖包的 llcppg.cfg 中也包含 deps 配置，系统会递归处理这些依赖.
3. 所有依赖包的类型映射都会被加载和注册到转换工程中.
4. 在当前工程中，某个头文件中存在对于第三方包的类型的引用，即直接从当前转换工程作用域进行查找
    * 如果找到映射类型，则进行引用；
    * 否则提示用户缺失的类型及其来源头文件，以便用户进行转换。

### 2.1依赖包结构
每个依赖包都遵循统一的文件组织结构：（以 xml2 为例）：
* 转换完成的Go源文件
1. HTMLtree.go (由 HTMLtree.h 生成)
2. HTMLparser.go (由 HTMLparser.h 生成)
* 配置文件
1. llcppg.cfg (依赖信息)
4. llcppg.pub (类型映射信息)

### 2.2 示例工程
```json
{
  "name":"xslt",
  "include": [
    "libxslt/xslt.h",
    "libxslt/security.h",
    "libexslt/exsltconfig.h"
  ],
  "deps": [
    "c",
    "github.com/goplus/..../xml2",
    "github.com/goplus/..../zlib"
  ]
}
```
在`libxslt/xslt.h` 中依赖了 `libxml2` 的 `xmlChar` 和 `xmlNodePtr`：

```c
#include <libxml/dict.h>
#include <libxml/xmlerror.h>
#include <libxml/xpath.h>
xmlChar * xsltGetNsProp(xmlNodePtr node, const xmlChar *name, const xmlChar *nameSpace);
```
如果 `xmlChar` 和 `xmlNodePtr` 未找到映射，`llcppg` 会提示用户这些类型缺失，并指明它们来自 `libxml2` 的头文件。

对应的提示信息会是
```bash
xmlChar not found in `/path/to/libxml/dict.h`.
xmlNodePtr not found in `/path/to/libxml/dict.h`.
```

### 2.3 类型映射示例
**标准库类型映射**
NOTE: "c" 是 "github.com/goplus/llgo/c" 的别名
`github.com/goplus/llgo/c/llcppg.pub`
```
size_t SizeT
intptr_t IntptrT
FILE
```
**XML2类型映射**
`github.com/goplus/..../xml2/llcppg.pub`
```
xml_doc XmlDoc
```

## 3.文件生成规则
### 3.1 生成文件类型
* 接口头文件:每个头文件生成对应的.go文件
* 实现文件:统一生成到ibname_autogen.go文件
###  3.2头文件归属判断
1. 接口头文件:
  *  include 中明确声明的头文件
2. 实现头文件
  *  与接口头文件位于相同根目录的其他头文件
#### 3.2.1 示例说明
例如，上方的例子中头文件通过 Clang 与库链接后获得的路径：
```bash
/opt/homebrew/Cellar/libxslt/1.1.42_1/include/libxslt/xslt.h
/opt/homebrew/Cellar/libxslt/1.1.42_1/include/libxslt/security.h
/opt/homebrew/Cellar/libxslt/1.1.42_1/include/libexslt/exsltconfig.h
```
计算出的公共根目录为：
```bash
/opt/homebrew/Cellar/libxslt/1.1.42_1/include/
```
在 libxslt/xslt.h 中引用了以下头文件：
```c
#include <libxml/tree.h>
#include "xsltexports.h"
```
对应的路径分别为
`libxml/tree.h` -> `/opt/homebrew/Cellar/libxml2/2.13.5/include/libxml2/libxml/tree.h`（第三方依赖）

`xsltexports.h` -> `/opt/homebrew/Cellar/libxslt/1.1.42_1/include/libxslt/xsltexports.h`（本包实现文件）

`xsltexports.h` 与 `libxslt/xslt.h` 位于相同目录下，因此视为当前包的实现文件，其内容生成在 `xslt_autogen.go` 中。而 `libxml/tree.h` 不在相同目录下，视为第三方依赖.

## 4. 特殊情况处理
### 4.1 系统路径处理
混合在系统路径下的第三方头文件，在linux的apt安装的库中会经常出现，例如 `/usr/include/sqlite3.h` 和 `/usr/include/stdio.h`）。
1. 配置方式
```json
{
  "mix": false
}
```
2. 处理规则
* include中明确声明的头文件即为所有本包头文件，在此之外的文件均视为三方头文件。

### 4.2  跨平台差异处理
使用 impl.files 配置处理平台差异：
```json
{
    "impl": [
        {
            "files": ["t1.h", "t2.h"],
            "cond": {
                "os": ["macos", "linux"],
                "arch": ["arm64", "amd64"]
            }
        }
    ]
}
```
那么生成的 `t1.go` & `t2.go` 文件的开头就会是在对应平台中就会各自生成其平台相关的条件编译指令
`macos arm64` ` t1_macos_arm64.go` ` t2_macos_arm64.go`
```
// +build macos,arm64

package xxx
```
`linux arm64` ` t1_linux_arm64.go` ` t2_linux_arm64.go`
```
// +build linux,arm64

package xxx
```
`macos amd64` ` t1_macos_amd64.go` ` t2_macos_amd64.go`
```
// +build macos,amd64

package xxx
```
`linux amd64` ` t1_linux_amd64.go` ` t2_linux_amd64.go`
```
// +build linux,amd64

package xxx
```