### PR TITLE
gogensig:refine _depcjson test

### DIFF
--- a/cmd/gogensig/convert/_testdata/_depcjson/conf/llcppg.cfg
+++ b/cmd/gogensig/convert/_testdata/_depcjson/conf/llcppg.cfg
@@ -1,6 +1,6 @@
 {
   "name": "depcjson",
-  "include": ["temp.h","thirddep.h"],
+  "include": ["temp.h"],
   "cflags" :"$(pkg-config --cflags libcjson)",
   "cplusplus":false,
   "deps": [

--- a/cmd/gogensig/convert/_testdata/_depcjson/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/_depcjson/hfile/temp.h
@@ -2,7 +2,7 @@
 #include <stddef.h>
 #include <thirddep.h>
 #include <thirddep2.h>
-#include <type.h>
+#include "type.h"
 // This file is supposed to depend on cjson in its cflags, but for testing,
 // we will simulate its API using libcjson instead.
 //   "cflags" :"$(pkg-config --cflags libcjson)"

--- a/cmd/gogensig/convert/convert.go
+++ b/cmd/gogensig/convert/convert.go
@@ -25,7 +25,6 @@ type Config struct {
 	CfgFile      string // llcppg.cfg
 	PubFile      string // llcppg.pub
 	OutputDir    string
-	PrepareFunc  func(*Package)
 }
 
 func NewAstConvert(config *Config) (*AstConvert, error) {

--- a/cmd/gogensig/convert/filesetprocessor/doc_fileset_processor.go
+++ b/cmd/gogensig/convert/filesetprocessor/doc_fileset_processor.go
@@ -130,9 +130,6 @@ func New(cfg *convert.Config) (*DocFileSetProcessor, *convert.Package, error) {
 		return nil, nil, err
 	}
 
-	if cfg.PrepareFunc != nil {
-		cfg.PrepareFunc(astConvert.Pkg)
-	}
 	docVisitors := []visitor.DocVisitor{astConvert}
 	visitorList := visitor.NewDocVisitorList(docVisitors)
 
@@ -158,9 +155,6 @@ func Process(cfg *convert.Config) error {
 		return err
 	}
 
-	if cfg.PrepareFunc != nil {
-		cfg.PrepareFunc(astConvert.Pkg)
-	}
 	docVisitors := []visitor.DocVisitor{astConvert}
 	visitorList := visitor.NewDocVisitorList(docVisitors)
 

--- a/cmd/gogensig/convert/testdata/thirddep/hfile/thirddep.h
+++ b/cmd/gogensig/convert/testdata/thirddep/hfile/thirddep.h
@@ -1,4 +1,4 @@
-#include <type.h>
+#include "type.h"
 #include <basicdep.h>
 
 struct third_dep

--- a/cmd/gogensig/convert/testdata/thirddep2/hfile/thirddep2.h
+++ b/cmd/gogensig/convert/testdata/thirddep2/hfile/thirddep2.h
@@ -1,4 +1,4 @@
-#include <type.h>
+#include "type.h"
 #include <thirddep.h>
 #include <basicdep.h>
 


### PR DESCRIPTION
input in tests matches gogensig's normal input, rather than dynamically concatenating cflags when loading dependencies