### PR TITLE
llcppg:-mod

### DIFF
--- a/cmd/gogensig/convert/convert.go
+++ b/cmd/gogensig/convert/convert.go
@@ -24,24 +24,29 @@ type Config struct {
 	Pkg *llcppg.Pkg
 }
 
+// if modulePath is not empty, init the module by modulePath
 func ModInit(deps []string, outputDir string, modulePath string) error {
-	err := cfg.RunCommand(outputDir, "go", "mod", "init", modulePath)
-	if err != nil {
-		return err
-	}
-	for _, dep := range deps {
-		_, std := IsDepStd(dep)
-		if std {
-			continue
-		}
-		err = cfg.RunCommand(outputDir, "go", "get", dep)
+	var err error
+	if modulePath != "" {
+		err = cfg.RunCommand(outputDir, "go", "mod", "init", modulePath)
 		if err != nil {
 			return err
 		}
 	}
-	err = cfg.RunCommand(outputDir, "go", "get", "github.com/goplus/llgo@v0.10.0")
-	if err != nil {
-		return err
+
+	loadDeps := []string{"github.com/goplus/llgo@v0.10.0"}
+
+	for _, dep := range deps {
+		_, std := IsDepStd(dep)
+		if !std {
+			loadDeps = append(loadDeps, dep)
+		}
+	}
+	for _, dep := range loadDeps {
+		err = cfg.RunCommand(outputDir, "go", "get", dep)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cmd/gogensig/convert/convert.go
+++ b/cmd/gogensig/convert/convert.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/goplus/llcppg/ast"
+
 	cfg "github.com/goplus/llcppg/cmd/gogensig/config"
 	"github.com/goplus/llcppg/cmd/gogensig/dbg"
 	"github.com/goplus/llcppg/llcppg"
@@ -21,6 +22,28 @@ type Config struct {
 	OutputDir string
 
 	Pkg *llcppg.Pkg
+}
+
+func ModInit(deps []string, outputDir string, modulePath string) error {
+	err := cfg.RunCommand(outputDir, "go", "mod", "init", modulePath)
+	if err != nil {
+		return err
+	}
+	for _, dep := range deps {
+		_, std := IsDepStd(dep)
+		if std {
+			continue
+		}
+		err = cfg.RunCommand(outputDir, "go", "get", dep)
+		if err != nil {
+			return err
+		}
+	}
+	err = cfg.RunCommand(outputDir, "go", "get", "github.com/goplus/llgo@v0.10.0")
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 type Converter struct {

--- a/cmd/gogensig/convert/convert.go
+++ b/cmd/gogensig/convert/convert.go
@@ -3,8 +3,6 @@ package convert
 import (
 	"errors"
 	"log"
-	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/goplus/llcppg/ast"
@@ -102,6 +100,7 @@ func (p *Converter) Convert() {
 	p.Process()
 	p.Write()
 	p.Fmt()
+	p.Tidy()
 }
 
 func (p *Converter) Process() {
@@ -162,13 +161,16 @@ func (p *Converter) Write() {
 }
 
 func (p *Converter) Fmt() {
-	cmd := exec.Command("go", "fmt", ".")
-	cmd.Dir = p.Conf.OutputDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
+	err := cfg.RunCommand(p.Conf.OutputDir, "go", "fmt", ".")
 	if err != nil {
 		log.Panicf("go fmt: %v\n", err)
+	}
+}
+
+func (p *Converter) Tidy() {
+	err := cfg.RunCommand(p.Conf.OutputDir, "go", "mod", "tidy")
+	if err != nil {
+		log.Panicf("go mod tidy: %v\n", err)
 	}
 }
 

--- a/cmd/gogensig/convert/convert_test.go
+++ b/cmd/gogensig/convert/convert_test.go
@@ -183,7 +183,7 @@ func testFrom(t *testing.T, name, dir string, gen bool, validateFunc func(t *tes
 			t.Fatal(err)
 		}
 	}()
-	outputDir, err := ModInit(name)
+	outputDir, err := prepareEnv(name, cfg.Deps)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +285,7 @@ func TestNewConvertReadPubFail(t *testing.T) {
 	}
 }
 
-func ModInit(name string) (string, error) {
+func prepareEnv(name string, deps []string) (string, error) {
 	tempDir, err := os.MkdirTemp("", "gogensig-test")
 	if err != nil {
 		return "", err
@@ -303,11 +303,7 @@ func ModInit(name string) (string, error) {
 		return "", err
 	}
 
-	err = config.RunCommand(outputDir, "go", "mod", "init", name)
-	if err != nil {
-		return "", err
-	}
-	err = config.RunCommand(outputDir, "go", "get", "github.com/goplus/llgo@v0.10.0")
+	err = convert.ModInit(deps, outputDir, name)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/gogensig/convert/convert_test.go
+++ b/cmd/gogensig/convert/convert_test.go
@@ -285,6 +285,29 @@ func TestNewConvertReadPubFail(t *testing.T) {
 	}
 }
 
+func TestModInitFail(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "gogensig-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	invalidMod := "github.com/user!name/project"
+
+	t.Run("mod init fail", func(t *testing.T) {
+		err = convert.ModInit([]string{}, tempDir, invalidMod)
+		if err == nil {
+			t.Fatal("no error")
+		}
+	})
+	t.Run("dep get fail", func(t *testing.T) {
+		err = convert.ModInit([]string{invalidMod}, tempDir, "")
+		if err == nil {
+			t.Fatal("no error")
+		}
+	})
+}
+
 func prepareEnv(name string, deps []string) (string, error) {
 	tempDir, err := os.MkdirTemp("", "gogensig-test")
 	if err != nil {

--- a/cmd/gogensig/convert/convert_test.go
+++ b/cmd/gogensig/convert/convert_test.go
@@ -308,6 +308,27 @@ func TestModInitFail(t *testing.T) {
 	})
 }
 
+func TestTidyFail(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expect panic")
+		}
+	}()
+
+	tempDir, err := os.MkdirTemp("", "gogensig-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	cvt := &convert.Converter{
+		Conf: &convert.Config{
+			OutputDir: tempDir,
+		},
+	}
+	cvt.Tidy()
+}
+
 func prepareEnv(name string, deps []string) (string, error) {
 	tempDir, err := os.MkdirTemp("", "gogensig-test")
 	if err != nil {

--- a/cmd/gogensig/gogensig.go
+++ b/cmd/gogensig/gogensig.go
@@ -100,23 +100,7 @@ func prepareEnv(wd, pkg string, deps []string) error {
 		return err
 	}
 
-	err = config.RunCommand(dir, "go", "mod", "init", pkg)
-	if err != nil {
-		return err
-	}
-
-	for _, dep := range deps {
-		_, std := convert.IsDepStd(dep)
-		if std {
-			continue
-		}
-		err := config.RunCommand(dir, "go", "get", dep)
-		if err != nil {
-			return err
-		}
-	}
-
-	return config.RunCommand(dir, "go", "get", "github.com/goplus/llgo@v0.10.0")
+	return convert.ModInit(deps, dir, pkg)
 }
 
 func printUsage() {

--- a/cmd/gogensig/gogensig.go
+++ b/cmd/gogensig/gogensig.go
@@ -44,10 +44,14 @@ func main() {
 	}
 
 	var cfgFile string
+	var modulePath string
 	for i := 0; i < len(remainArgs); i++ {
 		arg := remainArgs[i]
 		if strings.HasPrefix(arg, "-cfg=") {
 			cfgFile = args.StringArg(arg, llcppg.LLCPPG_CFG)
+		}
+		if strings.HasPrefix(arg, "-mod=") {
+			modulePath = args.StringArg(arg, "")
 		}
 	}
 	if cfgFile == "" {
@@ -59,7 +63,7 @@ func main() {
 	wd, err := os.Getwd()
 	check(err)
 
-	err = prepareEnv(wd, conf.Name, conf.Deps)
+	err = prepareEnv(wd, conf.Name, conf.Deps, modulePath)
 	check(err)
 
 	data, err := config.ReadSigfetchFile(filepath.Join(wd, ags.CfgFile))
@@ -87,7 +91,7 @@ func check(err error) {
 	}
 }
 
-func prepareEnv(wd, pkg string, deps []string) error {
+func prepareEnv(wd, pkg string, deps []string, modulePath string) error {
 	dir := filepath.Join(wd, pkg)
 
 	err := os.MkdirAll(dir, 0744)
@@ -100,9 +104,9 @@ func prepareEnv(wd, pkg string, deps []string) error {
 		return err
 	}
 
-	return convert.ModInit(deps, dir, pkg)
+	return convert.ModInit(deps, dir, modulePath)
 }
 
 func printUsage() {
-	fmt.Fprintln(os.Stderr, "Usage: gogensig [-v|-cfg] [sigfetch-file]")
+	fmt.Fprintln(os.Stderr, "Usage: gogensig [-v|-cfg|-mod] [sigfetch-file]")
 }

--- a/cmd/llcppgtest/demo/demo.go
+++ b/cmd/llcppgtest/demo/demo.go
@@ -52,7 +52,7 @@ func RunGenPkgDemo(demoRoot string, confDir string) {
 		panic(fmt.Sprintf("config file not found: %s", configFile))
 	}
 
-	llcppgArgs := []string{"-v"}
+	llcppgArgs := []string{"-v", "-mod", demoPkgName}
 
 	outDir := filepath.Join(absPath, "out")
 	if err = os.MkdirAll(outDir, 0755); err != nil {


### PR DESCRIPTION
support https://github.com/goplus/llcppg/issues/215
* llcppg -mod <module-path> determine need init a go.mod,if not specifc, dont init a new go module.
* tidy when converted end.