### PR TITLE
gogensig:gen blank import for all deps

### DIFF
--- a/_llcppgtest/libxml2/llcppg.cfg
+++ b/_llcppgtest/libxml2/llcppg.cfg
@@ -50,7 +50,7 @@
 		"libxml/xmlversion.h",
 		"libxml/xmlexports.h"
 	],
-	"deps":["c","c/os"],
+	"deps":["c","c/os","github.com/goplus/llpkg/zlib@v1.0.0"],
 	"trimPrefixes": [],
 	"cplusplus": false
 }

--- a/cmd/gogensig/convert/_testdata/_depcjson/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/_depcjson/gogensig.expect
@@ -11,6 +11,14 @@ type X_depcjsonType c.Int
 ===== depcjson_autogen_link.go =====
 package depcjson
 
+import (
+	_ "github.com/goplus/llcppg/cmd/gogensig/convert/testdata/cjson"
+	_ "github.com/goplus/llcppg/cmd/gogensig/convert/testdata/thirddep"
+	_ "github.com/goplus/llcppg/cmd/gogensig/convert/testdata/thirddep2"
+	_ "github.com/goplus/llcppg/cmd/gogensig/convert/testdata/thirddep3"
+	_ "github.com/goplus/llgo/c"
+)
+
 const LLGoPackage string = "link: $(pkg-config --libs libcjson);"
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/_depwithversion/conf/llcppg.cfg
+++ b/cmd/gogensig/convert/_testdata/_depwithversion/conf/llcppg.cfg
@@ -5,7 +5,8 @@
   "libs": "$(pkg-config --libs xxx)",
   "cplusplus":false,
   "deps": [
-    "github.com/goplus/llpkg/libxml2@v1.0.0"
+    "github.com/goplus/llpkg/libxml2@v1.0.0",
+    "github.com/goplus/llpkg/zlib@v1.0.0"
   ],
   "mix":true
 }

--- a/cmd/gogensig/convert/_testdata/_depwithversion/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/_depwithversion/gogensig.expect
@@ -1,6 +1,12 @@
 ===== depwithversion_autogen_link.go =====
 package depwithversion
 
+import (
+	_ "github.com/goplus/llgo/c"
+	_ "github.com/goplus/llpkg/libxml2"
+	_ "github.com/goplus/llpkg/zlib"
+)
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/_systopkg/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/_systopkg/gogensig.expect
@@ -1,6 +1,11 @@
 ===== systopkg_autogen_link.go =====
 package systopkg
 
+import (
+	_ "github.com/goplus/llgo/c"
+	_ "github.com/goplus/llgo/c/time"
+)
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/avoidkeyword/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/avoidkeyword/gogensig.expect
@@ -1,6 +1,8 @@
 ===== avoidkeyword_autogen_link.go =====
 package avoidkeyword
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/cjson/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/cjson/gogensig.expect
@@ -509,6 +509,8 @@ func (recv_ *JSON) SortObjectCaseSensitive() {
 ===== cjson_autogen_link.go =====
 package cjson
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== llcppg.pub =====

--- a/cmd/gogensig/convert/_testdata/enum/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/enum/gogensig.expect
@@ -1,6 +1,8 @@
 ===== enum_autogen_link.go =====
 package enum
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/forwarddecl/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/forwarddecl/gogensig.expect
@@ -1,6 +1,8 @@
 ===== forwarddecl_autogen_link.go =====
 package forwarddecl
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== impl.go =====

--- a/cmd/gogensig/convert/_testdata/funcrefer/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/funcrefer/gogensig.expect
@@ -1,6 +1,8 @@
 ===== funcrefer_autogen_link.go =====
 package funcrefer
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/gpgerror/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/gpgerror/gogensig.expect
@@ -80,6 +80,8 @@ func (recv_ *GpgrtLockT) LockDestroy() CodeT {
 ===== gpgerror_autogen_link.go =====
 package gpgerror
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs gpg-error);"
 
 ===== gpgrt.go =====

--- a/cmd/gogensig/convert/_testdata/ignoresym/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/ignoresym/gogensig.expect
@@ -1,6 +1,8 @@
 ===== ignoresym_autogen_link.go =====
 package ignoresym
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/impls/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/impls/gogensig.expect
@@ -13,6 +13,8 @@ type X_foo struct {
 ===== impls_autogen_link.go =====
 package impls
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== inter.go =====

--- a/cmd/gogensig/convert/_testdata/keepcomment/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/keepcomment/gogensig.expect
@@ -1,6 +1,8 @@
 ===== keepcomment_autogen_link.go =====
 package keepcomment
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/lua/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/lua/gogensig.expect
@@ -613,6 +613,8 @@ type CallInfo struct {
 ===== lua_autogen_link.go =====
 package lua
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs lua);"
 
 ===== luaconf.go =====

--- a/cmd/gogensig/convert/_testdata/macro/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/macro/gogensig.expect
@@ -23,5 +23,7 @@ const X_MACRO_UNDER = 0xFFF
 ===== macro_autogen_link.go =====
 package macro
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 

--- a/cmd/gogensig/convert/_testdata/mix/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/mix/gogensig.expect
@@ -30,6 +30,8 @@ type X_mixType struct {
 ===== mix_autogen_link.go =====
 package mix
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== llcppg.pub =====

--- a/cmd/gogensig/convert/_testdata/nested/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/nested/gogensig.expect
@@ -1,6 +1,8 @@
 ===== nested_autogen_link.go =====
 package nested
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/pubfile/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/pubfile/gogensig.expect
@@ -1,6 +1,8 @@
 ===== pubfile_autogen_link.go =====
 package pubfile
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/pubprivate/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/pubprivate/gogensig.expect
@@ -1,6 +1,8 @@
 ===== pubprivate_autogen_link.go =====
 package pubprivate
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/receiver/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/receiver/gogensig.expect
@@ -1,6 +1,8 @@
 ===== receiver_autogen_link.go =====
 package receiver
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/selfref/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/selfref/gogensig.expect
@@ -1,6 +1,8 @@
 ===== selfref_autogen_link.go =====
 package selfref
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/sqlite/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/sqlite/gogensig.expect
@@ -724,6 +724,8 @@ type LoadextEntry func(*Sqlite3, **int8, *ApiRoutines) c.Int
 ===== sqlite_autogen_link.go =====
 package sqlite
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs sqlite3);"
 
 ===== llcppg.pub =====

--- a/cmd/gogensig/convert/_testdata/stdtype/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/stdtype/gogensig.expect
@@ -1,6 +1,8 @@
 ===== stdtype_autogen_link.go =====
 package stdtype
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== temp.go =====

--- a/cmd/gogensig/convert/_testdata/union/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/union/gogensig.expect
@@ -14,6 +14,8 @@ type U X__u
 ===== union_autogen_link.go =====
 package union
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== llcppg.pub =====

--- a/cmd/gogensig/convert/_testdata/xml2/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/xml2/gogensig.expect
@@ -166,6 +166,8 @@ type X_xmlDict struct {
 ===== xml2_autogen_link.go =====
 package xml2
 
+import _ "github.com/goplus/llgo/c"
+
 const LLGoPackage string = "link: $(pkg-config --libs xxx);"
 
 ===== xmlexports.go =====

--- a/cmd/gogensig/convert/convert_test.go
+++ b/cmd/gogensig/convert/convert_test.go
@@ -38,7 +38,10 @@ func TestDepWithVersion(t *testing.T) {
 			t.Fatal("Read go.mod failed:", err)
 		}
 		if !strings.Contains(string(modContent), "libxml2 v1.0.0") {
-			t.Fatal("go.mod does not contain libxml2 v1.0.0")
+			t.Fatal(string(modContent), "\ngo.mod does not contain libxml2 v1.0.0")
+		}
+		if !strings.Contains(string(modContent), "zlib v1.0.0") {
+			t.Fatal(string(modContent), "\ngo.mod does not contain zlib v1.0.0")
 		}
 	})
 }

--- a/cmd/gogensig/convert/deps.go
+++ b/cmd/gogensig/convert/deps.go
@@ -79,14 +79,14 @@ func (pm *PkgDepLoader) Import(pkgPath string) (*PkgInfo, error) {
 	if pm.module == nil {
 		return nil, errs.NewModNotFoundError()
 	}
-	if pkg, exist := pm.pkgCache[pkgPath]; exist {
-		return pkg, nil
-	}
 
 	// standard C library paths
 	pkgPath, isStd := IsDepStd(pkgPath)
-
 	pkgPath, _ = splitPkgPath(pkgPath)
+
+	if pkg, exist := pm.pkgCache[pkgPath]; exist {
+		return pkg, nil
+	}
 
 	pkg, err := pm.module.Lookup(pkgPath)
 	if err != nil {

--- a/cmd/gogensig/convert/package_bulitin_test.go
+++ b/cmd/gogensig/convert/package_bulitin_test.go
@@ -149,3 +149,19 @@ func TestTrimPrefixes(t *testing.T) {
 		t.Errorf("Expected Empty TrimPrefix")
 	}
 }
+
+func TestMarkUseFail(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Expected panic, got nil")
+		}
+	}()
+	pkg := NewPackage(&PackageConfig{
+		PkgBase: PkgBase{
+			PkgPath:  ".",
+			CppgConf: &llcppg.Config{},
+			Pubs:     make(map[string]string),
+		},
+	})
+	pkg.markUseDeps(&PkgDepLoader{})
+}


### PR DESCRIPTION
resolved https://github.com/goplus/llcppg/issues/226

use blank import for every deps in `lib_autogen_link.go` to support indirect dep of lots of c package.
such as libxml2 ,also in header file,libxml2 not rely zlib's type,but in the runtime,with out the zlib's binaries will cause panic,llpkg need this feature to get these runtime dependency.
