### PR TITLE
gogensig:check load same llcppg.pub's pubname

### DIFF
--- a/cmd/gogensig/convert/_testdata/_depcjson/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/_depcjson/gogensig.expect
@@ -46,3 +46,19 @@ func ThirdDepfn(a *thirddep.ThirdDep, b *thirddep2.ThirdDep2, c X_depcjsonType, 
 //go:linkname ThirdType C.third_type
 func ThirdType(a *thirddep3.ThirdDep3) thirddep3.ThirdDep3
 
+// This struct demonstrates the handling of same llcppg.pub names across different packages:
+//
+// 1. Basic_stream (from basicdep.h)
+//   - Indirect dependency
+//   - llcppg.pub mapping: Basic_stream -> Stream
+//
+// 2. third_dep_stream (from thirddep.h)
+//   - Direct dependency
+//   - llcppg.pub mapping: third_dep_stream -> Stream
+type SamePubStream struct {
+	BasicStream    basicdep.Stream
+	ThirdDepStream thirddep.Stream
+}
+
+===== llcppg.pub =====
+samePubStream SamePubStream

--- a/cmd/gogensig/convert/_testdata/_depcjson/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/_depcjson/hfile/temp.h
@@ -16,3 +16,18 @@ cJSON_bool serialize_response(cJSON *response, char *buffer, const int length, c
 third_dep third_depfn(third_dep *a, third_dep2 *b, _depcjson_type c, basic_dep d);
 
 third_dep3 third_type(third_dep3 *a);
+    
+// This struct demonstrates the handling of same llcppg.pub names across different packages:
+//
+// 1. Basic_stream (from basicdep.h)
+//    - Indirect dependency
+//    - llcppg.pub mapping: Basic_stream -> Stream
+//
+// 2. third_dep_stream (from thirddep.h)
+//    - Direct dependency
+//    - llcppg.pub mapping: third_dep_stream -> Stream
+typedef struct samePubStream {
+    Basic_stream basic_stream;
+    third_dep_stream third_dep_stream;
+} samePubStream;
+

--- a/cmd/gogensig/convert/testdata/basicdep/basicdep.go
+++ b/cmd/gogensig/convert/testdata/basicdep/basicdep.go
@@ -4,3 +4,4 @@ import "github.com/goplus/llgo/c"
 
 type BasicDep c.Long
 type Basic c.Long
+type Stream c.Long

--- a/cmd/gogensig/convert/testdata/basicdep/hfile/basicdep.h
+++ b/cmd/gogensig/convert/testdata/basicdep/hfile/basicdep.h
@@ -1,2 +1,3 @@
 typedef long basic_dep;
 typedef long Basic;
+typedef long Basic_stream;

--- a/cmd/gogensig/convert/testdata/basicdep/llcppg.pub
+++ b/cmd/gogensig/convert/testdata/basicdep/llcppg.pub
@@ -1,2 +1,3 @@
 basic_dep BasicDep
 Basic
+Basic_stream Stream

--- a/cmd/gogensig/convert/testdata/thirddep/hfile/thirddep.h
+++ b/cmd/gogensig/convert/testdata/thirddep/hfile/thirddep.h
@@ -6,3 +6,4 @@ struct third_dep
     type_third_dep a;
     type_third_dep b;
 };
+typedef long third_dep_stream;

--- a/cmd/gogensig/convert/testdata/thirddep/llcppg.pub
+++ b/cmd/gogensig/convert/testdata/thirddep/llcppg.pub
@@ -1,2 +1,3 @@
 third_dep ThirdDep
 type_third_dep TypeThirdDep
+third_dep_stream Stream

--- a/cmd/gogensig/convert/testdata/thirddep/thirddep.go
+++ b/cmd/gogensig/convert/testdata/thirddep/thirddep.go
@@ -1,8 +1,14 @@
 package thirddep
 
-import _ "unsafe"
+import (
+	_ "unsafe"
+
+	"github.com/goplus/llgo/c"
+)
 
 type ThirdDep struct {
 	A TypeThirdDep
 	B TypeThirdDep
 }
+
+type Stream c.Long


### PR DESCRIPTION
verify that depcjson can correctly reference the types from both packages, ensuring that there are no conflicts when using the same pubname.

**Handling Same pubname:**
In the basicdep package, the type `Basic_stream` is defined and mapped to `Stream`.
In the thirddep package, the type `third_dep_stream` is also defined and mapped to `Stream`.
**Output:**
A struct named `SamePubStream` has been added, which includes types with the same name from two different packages:
```go
 type SamePubStream struct {
    BasicStream    basicdep.Stream
    ThirdDepStream thirddep.Stream
 }
```
