### PR TITLE
ci:update to go 1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Set up Go for testing
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.23'
 
     - name: Install llcppg modules
       run: |


### PR DESCRIPTION
In Go 1.21 and earlier versions, go test would ignore packages without _test.go files when calculating test coverage. However, in Go 1.22 and later versions, go test includes all packages in the test coverage calculation, even those without test cases. Due to this change, the scope of coverage calculation has expanded, which might lead to a slight drop in coverage, as packages without tests are now also counted in the coverage statistics.

