### PR TITLE
deps:gogen v1.17.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	github.com/google/go-cmp v0.6.0
-	github.com/goplus/gogen v1.16.9
+	github.com/goplus/gogen v1.17.1
 	github.com/goplus/llgo v0.10.0
 	github.com/goplus/llpkg/cjson v1.0.0
 	github.com/goplus/mod v0.13.12
@@ -13,7 +13,4 @@ require (
 require (
 	github.com/qiniu/x v1.13.10 // indirect
 	golang.org/x/mod v0.23.0 // indirect
-	golang.org/x/tools v0.19.0 // indirect
 )
-
-replace golang.org/x/tools => golang.org/x/tools v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/goplus/gogen v1.16.9 h1:BRNAsRzdyMcLBOLUe6+suVMmOe+D2HLfF7mAkS4/QW4=
-github.com/goplus/gogen v1.16.9/go.mod h1:6TQYbabXDF9LCdDkOOzHmfg1R4ENfXQ3XpHa9RhTSD8=
+github.com/goplus/gogen v1.17.1 h1:dx1KoggI3jK0ti4GyQAJMPAib81BP2uePA8xQ9dMJlU=
+github.com/goplus/gogen v1.17.1/go.mod h1:owX2e1EyU5WD+Nm6oH2m/GXjLdlBYcwkLO4wN8HHXZI=
 github.com/goplus/llgo v0.10.0 h1:s3U3cnO3cploF1xCCJleAb16NQFAmHxdUmdrNhRH3hY=
 github.com/goplus/llgo v0.10.0/go.mod h1:YfOHsT/g3lc9b4GclLj812YzdSsJr0kd3CCB830TqHE=
 github.com/goplus/llpkg/cjson v1.0.0 h1:yPKe1E976qfimxh0m+IWEZwEtJn91zMMKBYZFQwfZy0=
@@ -12,7 +12,3 @@ github.com/qiniu/x v1.13.10 h1:J4Z3XugYzAq85SlyAfqlKVrbf05glMbAOh+QncsDQpE=
 github.com/qiniu/x v1.13.10/go.mod h1:INZ2TSWSJVWO/RuELQROERcslBwVgFG7MkTfEdaQz9E=
 golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
 golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
-golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
-golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
-golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=


### PR DESCRIPTION
https://github.com/goplus/gogen/pull/489 fix unexpect alias's zerolit
https://github.com/goplus/gogen/pull/490 support we can without `replace golang.org/x/tools => golang.org/x/tools v0.30.0` to refer a alias
