### PR TITLE
ci:feat: split genpkg tests to enhance speed of ci

### DIFF
--- a/.github/actions/setup-llcppg/action.yml
+++ b/.github/actions/setup-llcppg/action.yml
@@ -25,7 +25,7 @@ runs:
     with:
       go-version: ${{inputs.go-version}}
   - name: Install dependencies
-    if: startsWith(matrix.os, 'macos')
+    if: runner.os == 'macOS'
     shell: bash
     run: |
       brew update
@@ -37,7 +37,7 @@ runs:
       brew install cjson
   - name: Install dependencies
     shell: bash
-    if: startsWith(matrix.os, 'ubuntu')
+    if: runner.os == 'Linux'
     run: |
       echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{matrix.llvm}} main" | sudo tee /etc/apt/sources.list.d/llvm.list
       wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -

--- a/.github/actions/setup-llcppg/action.yml
+++ b/.github/actions/setup-llcppg/action.yml
@@ -1,0 +1,58 @@
+name: "Setup llcppg"
+description: "Install dependencies, set up Go, set up LLGo, install llcppg"
+inputs:
+  go-version:
+    description: "Go version to install"
+    default: "1.23"
+  llvm-version:
+    description: "LLVM version to install (e.g. 18)"
+    default: "18"
+  llgo-version:
+    description: "LLGo git ref or tag"
+    default: "v0.10.0"
+runs:
+  using: "composite"
+  steps:
+  - uses: actions/checkout@v4
+  - name: Checkout LLGo
+    uses: actions/checkout@v4
+    with:
+      repository: 'goplus/llgo'
+      path: '.llgo'
+      ref: ${{inputs.llgo-version}}
+  - name: Set up Go
+    uses: actions/setup-go@v4
+    with:
+      go-version: ${{inputs.go-version}}
+  - name: Install dependencies
+    if: startsWith(matrix.os, 'macos')
+    run: |
+      brew update
+      brew install llvm@${{matrix.llvm}} bdw-gc openssl libffi libuv
+      brew link --force libffi
+      echo "$(brew --prefix llvm@${{matrix.llvm}})/bin" >> $GITHUB_PATH
+
+      # llcppg dependencies
+      brew install cjson
+  - name: Install dependencies
+    if: startsWith(matrix.os, 'ubuntu')
+    run: |
+      echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{matrix.llvm}} main" | sudo tee /etc/apt/sources.list.d/llvm.list
+      wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+      sudo apt-get update
+      sudo apt-get install -y llvm-${{matrix.llvm}}-dev clang-${{matrix.llvm}} libunwind-dev libclang-${{matrix.llvm}}-dev lld-${{matrix.llvm}} pkg-config libgc-dev libssl-dev zlib1g-dev libffi-dev libcjson-dev libuv1-dev
+      echo "/usr/lib/llvm-${{matrix.llvm}}/bin" >> $GITHUB_PATH
+  - name: Install LLGo
+    working-directory: .llgo
+    run: |
+      cd compiler
+      go install -v ./cmd/...
+      export LLGO_ROOT=$GITHUB_WORKSPACE/llgo
+      echo "LLGO_ROOT=$LLGO_ROOT" >> $GITHUB_ENV
+  - name: Build
+    run: go build -v ./...
+
+  - name: Install llcppg modules
+    run: |
+      echo "Using LLGO_ROOT: $LLGO_ROOT"
+      bash ./install.sh

--- a/.github/actions/setup-llcppg/action.yml
+++ b/.github/actions/setup-llcppg/action.yml
@@ -29,9 +29,9 @@ runs:
     shell: bash
     run: |
       brew update
-      brew install llvm@${{matrix.llvm}} bdw-gc openssl libffi libuv
+      brew install llvm@${{inputs.llvm}} bdw-gc openssl libffi libuv
       brew link --force libffi
-      echo "$(brew --prefix llvm@${{matrix.llvm}})/bin" >> $GITHUB_PATH
+      echo "$(brew --prefix llvm@${{inputs.llvm}})/bin" >> $GITHUB_PATH
 
       # llcppg dependencies
       brew install cjson
@@ -39,11 +39,11 @@ runs:
     shell: bash
     if: runner.os == 'Linux'
     run: |
-      echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{matrix.llvm}} main" | sudo tee /etc/apt/sources.list.d/llvm.list
+      echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{inputs.llvm}} main" | sudo tee /etc/apt/sources.list.d/llvm.list
       wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
       sudo apt-get update
-      sudo apt-get install -y llvm-${{matrix.llvm}}-dev clang-${{matrix.llvm}} libunwind-dev libclang-${{matrix.llvm}}-dev lld-${{matrix.llvm}} pkg-config libgc-dev libssl-dev zlib1g-dev libffi-dev libcjson-dev libuv1-dev
-      echo "/usr/lib/llvm-${{matrix.llvm}}/bin" >> $GITHUB_PATH
+      sudo apt-get install -y llvm-${{inputs.llvm}}-dev clang-${{inputs.llvm}} libunwind-dev libclang-${{inputs.llvm}}-dev lld-${{inputs.llvm}} pkg-config libgc-dev libssl-dev zlib1g-dev libffi-dev libcjson-dev libuv1-dev
+      echo "/usr/lib/llvm-${{inputs.llvm}}/bin" >> $GITHUB_PATH
   - name: Install LLGo
     shell: bash
     working-directory: .llgo

--- a/.github/actions/setup-llcppg/action.yml
+++ b/.github/actions/setup-llcppg/action.yml
@@ -1,13 +1,13 @@
 name: "Setup llcppg"
 description: "Install dependencies, set up Go, set up LLGo, install llcppg"
 inputs:
-  go-version:
+  go:
     description: "Go version to install"
     default: "1.23"
-  llvm-version:
+  llvm:
     description: "LLVM version to install (e.g. 18)"
     default: "18"
-  llgo-version:
+  llgo:
     description: "LLGo git ref or tag"
     default: "v0.10.0"
 runs:
@@ -19,11 +19,11 @@ runs:
     with:
       repository: 'goplus/llgo'
       path: '.llgo'
-      ref: ${{inputs.llgo-version}}
+      ref: ${{inputs.llgo}}
   - name: Set up Go
     uses: actions/setup-go@v4
     with:
-      go-version: ${{inputs.go-version}}
+      go-version: ${{inputs.go}}
   - name: Install dependencies
     if: runner.os == 'macOS'
     shell: bash

--- a/.github/actions/setup-llcppg/action.yml
+++ b/.github/actions/setup-llcppg/action.yml
@@ -26,6 +26,7 @@ runs:
       go-version: ${{inputs.go-version}}
   - name: Install dependencies
     if: startsWith(matrix.os, 'macos')
+    shell: bash
     run: |
       brew update
       brew install llvm@${{matrix.llvm}} bdw-gc openssl libffi libuv
@@ -35,6 +36,7 @@ runs:
       # llcppg dependencies
       brew install cjson
   - name: Install dependencies
+    shell: bash
     if: startsWith(matrix.os, 'ubuntu')
     run: |
       echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{matrix.llvm}} main" | sudo tee /etc/apt/sources.list.d/llvm.list
@@ -43,6 +45,7 @@ runs:
       sudo apt-get install -y llvm-${{matrix.llvm}}-dev clang-${{matrix.llvm}} libunwind-dev libclang-${{matrix.llvm}}-dev lld-${{matrix.llvm}} pkg-config libgc-dev libssl-dev zlib1g-dev libffi-dev libcjson-dev libuv1-dev
       echo "/usr/lib/llvm-${{matrix.llvm}}/bin" >> $GITHUB_PATH
   - name: Install LLGo
+    shell: bash
     working-directory: .llgo
     run: |
       cd compiler
@@ -50,9 +53,11 @@ runs:
       export LLGO_ROOT=$GITHUB_WORKSPACE/llgo
       echo "LLGO_ROOT=$LLGO_ROOT" >> $GITHUB_ENV
   - name: Build
+    shell: bash
     run: go build -v ./...
 
   - name: Install llcppg modules
+    shell: bash
     run: |
       echo "Using LLGO_ROOT: $LLGO_ROOT"
       bash ./install.sh

--- a/.github/actions/setup-llcppg/action.yml
+++ b/.github/actions/setup-llcppg/action.yml
@@ -50,7 +50,7 @@ runs:
     run: |
       cd compiler
       go install -v ./cmd/...
-      export LLGO_ROOT=$GITHUB_WORKSPACE/llgo
+      export LLGO_ROOT=$GITHUB_WORKSPACE/.llgo
       echo "LLGO_ROOT=$LLGO_ROOT" >> $GITHUB_ENV
   - name: Build
     shell: bash

--- a/.github/workflows/gentest.yml
+++ b/.github/workflows/gentest.yml
@@ -1,0 +1,59 @@
+name: Test Demo With Generated Pkgs
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+
+  test:
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-24.04
+        llvm: [18]
+        llgo: [v0.10.0]
+        go: [1.23]
+    runs-on: ${{matrix.os}}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup llcppg environment
+      uses: ./.github/actions/setup-llcppg
+      with:
+        go-version: ${{ matrix.go }}
+        llvm-version: ${{ matrix.llvm }}
+        llgo-version: ${{ matrix.llgo }}
+
+    - name: Test demos with generated pkgs
+      if: startsWith(matrix.os, 'macos')
+      run: |
+        # install demo's lib
+        brew install lua zlib isl libgpg-error raylib z3 sqlite3 gmp libxml2 libxslt
+
+        export PKG_CONFIG_PATH="/opt/homebrew/opt/zlib/lib/pkgconfig"
+        export PKG_CONFIG_PATH="/opt/homebrew/opt/sqlite/lib/pkgconfig:$PKG_CONFIG_PATH"
+        export PKG_CONFIG_PATH="/opt/homebrew/opt/libxml2/lib/pkgconfig:$PKG_CONFIG_PATH"
+        export PKG_CONFIG_PATH="/opt/homebrew/opt/libxslt/lib/pkgconfig:$PKG_CONFIG_PATH"
+        pkg-config --cflags --libs sqlite3
+        pkg-config --cflags --libs libxslt
+
+        llcppgtest -demos ./_llcppgtest
+
+    - name: Test demos with generated pkgs
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+        # install demo's lib
+        sudo apt install liblua5.4-dev libsqlite3-dev libgmp-dev libgpg-error-dev zlib1g-dev libisl-dev libz3-dev -y
+        llcppgtest -demo ./_llcppgtest/cjson -conf conf/linux
+        llcppgtest -demo ./_llcppgtest/gmp -conf conf/linux
+        llcppgtest -demo ./_llcppgtest/gpgerror -conf conf/linux
+        llcppgtest -demo ./_llcppgtest/isl
+        llcppgtest -demo ./_llcppgtest/lua -conf conf/linux
+        llcppgtest -demo ./_llcppgtest/sqlite -conf conf/linux
+        llcppgtest -demo ./_llcppgtest/z3 -conf conf/linux
+        llcppgtest -demo ./_llcppgtest/zlib -conf conf/linux
+
+

--- a/.github/workflows/gentest.yml
+++ b/.github/workflows/gentest.yml
@@ -23,9 +23,9 @@ jobs:
     - name: Setup llcppg environment
       uses: ./.github/actions/setup-llcppg
       with:
-        go-version: ${{ matrix.go }}
-        llvm-version: ${{ matrix.llvm }}
-        llgo-version: ${{ matrix.llgo }}
+        go: ${{ matrix.go }}
+        llvm: ${{ matrix.llvm }}
+        llgo: ${{ matrix.llgo }}
 
     - name: Test demos with generated pkgs
       if: startsWith(matrix.os, 'macos')

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,9 +26,9 @@ jobs:
     - name: Setup llcppg environment
       uses: ./.github/actions/setup-llcppg
       with:
-        go-version: ${{ matrix.go }}
-        llvm-version: ${{ matrix.llvm }}
-        llgo-version: ${{ matrix.llgo }}
+        go: ${{ matrix.go }}
+        llvm: ${{ matrix.llvm }}
+        llgo: ${{ matrix.llgo }}
 
     - name: Test llcppsymg & llcppsigfetch
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -77,34 +77,3 @@ jobs:
         ln -s $libdir/pkgconfig/python-3.12-embed.pc $pcdir/python3-embed.pc
         export PKG_CONFIG_PATH=$pcdir
         bash .github/workflows/test_demo.sh
-
-    - name: Test demos with generated pkgs
-      if: startsWith(matrix.os, 'macos')
-      run: |
-        # install demo's lib
-        brew install lua zlib isl libgpg-error raylib z3 sqlite3 gmp libxml2 libxslt
-
-        export PKG_CONFIG_PATH="/opt/homebrew/opt/zlib/lib/pkgconfig"
-        export PKG_CONFIG_PATH="/opt/homebrew/opt/sqlite/lib/pkgconfig:$PKG_CONFIG_PATH"
-        export PKG_CONFIG_PATH="/opt/homebrew/opt/libxml2/lib/pkgconfig:$PKG_CONFIG_PATH"
-        export PKG_CONFIG_PATH="/opt/homebrew/opt/libxslt/lib/pkgconfig:$PKG_CONFIG_PATH"
-        pkg-config --cflags --libs sqlite3
-        pkg-config --cflags --libs libxslt
-
-        llcppgtest -demos ./_llcppgtest
-
-    - name: Test demos with generated pkgs
-      if: startsWith(matrix.os, 'ubuntu')
-      run: |
-        # install demo's lib
-        sudo apt install liblua5.4-dev libsqlite3-dev libgmp-dev libgpg-error-dev zlib1g-dev libisl-dev libz3-dev -y
-        llcppgtest -demo ./_llcppgtest/cjson -conf conf/linux
-        llcppgtest -demo ./_llcppgtest/gmp -conf conf/linux
-        llcppgtest -demo ./_llcppgtest/gpgerror -conf conf/linux
-        llcppgtest -demo ./_llcppgtest/isl
-        llcppgtest -demo ./_llcppgtest/lua -conf conf/linux
-        llcppgtest -demo ./_llcppgtest/sqlite -conf conf/linux
-        llcppgtest -demo ./_llcppgtest/z3 -conf conf/linux
-        llcppgtest -demo ./_llcppgtest/zlib -conf conf/linux
-
-

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,7 @@ jobs:
         go: [1.23]
     runs-on: ${{matrix.os}}
     steps:
+    - uses: actions/checkout@v4
     - name: Setup llcppg environment
       uses: ./.github/actions/setup-llcppg
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,56 +19,15 @@ jobs:
           - ubuntu-24.04
         llvm: [18]
         llgo: [v0.10.0]
+        go: [1.23]
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v4
-    - name: Checkout LLGo
-      uses: actions/checkout@v4
+    - name: Setup llcppg environment
+      uses: ./.github/actions/setup-llcppg
       with:
-        repository: 'goplus/llgo'
-        path: '.llgo'
-        ref: ${{matrix.llgo}}
-
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.23'
-
-    - name: Install dependencies
-      if: startsWith(matrix.os, 'macos')
-      run: |
-        brew update
-        brew install llvm@${{matrix.llvm}} bdw-gc openssl libffi libuv
-        brew link --force libffi
-        echo "$(brew --prefix llvm@${{matrix.llvm}})/bin" >> $GITHUB_PATH
-
-        # llcppg dependencies
-        brew install cjson
-
-    - name: Install dependencies
-      if: startsWith(matrix.os, 'ubuntu')
-      run: |
-        echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{matrix.llvm}} main" | sudo tee /etc/apt/sources.list.d/llvm.list
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo apt-get update
-        sudo apt-get install -y llvm-${{matrix.llvm}}-dev clang-${{matrix.llvm}} libunwind-dev libclang-${{matrix.llvm}}-dev lld-${{matrix.llvm}} pkg-config libgc-dev libssl-dev zlib1g-dev libffi-dev libcjson-dev libuv1-dev
-        echo "/usr/lib/llvm-${{matrix.llvm}}/bin" >> $GITHUB_PATH
-
-    - name: Install LLGo
-      working-directory: .llgo
-      run: |
-        cd compiler
-        go install -v ./cmd/...
-        export LLGO_ROOT=$GITHUB_WORKSPACE/llgo
-        echo "LLGO_ROOT=$LLGO_ROOT" >> $GITHUB_ENV
-
-    - name: Build
-      run: go build -v ./...
-
-    - name: Install llcppg modules
-      run: |
-        echo "Using LLGO_ROOT: $LLGO_ROOT"
-        bash ./install.sh
+        go-version: ${{ matrix.go }}
+        llvm-version: ${{ matrix.llvm }}
+        llgo-version: ${{ matrix.llgo }}
 
     - name: Test llcppsymg & llcppsigfetch
       run: |


### PR DESCRIPTION
This PR splits the llcppg demo tests from the unit tests, so that demo tests can begin downloading dependencies and running without having to wait for the unit tests to complete. Key changes include:

Separating the genpkg test logic into its own workflow.

Adding a composite action (setup-llcppg) to handle environment setup and dependency installation independently.

By splitting these testing processes, we aim to improve CI efficiency through parallel execution and reduce overall test duration. Please review and let me know if you have any questions or suggestions.