### PR TITLE
gogensig:return empty named struct type instead anonymous struct lit

### DIFF
--- a/cmd/gogensig/convert/_testdata/methodreturn/conf/llcppg.cfg
+++ b/cmd/gogensig/convert/_testdata/methodreturn/conf/llcppg.cfg
@@ -1,0 +1,6 @@
+{
+  "name": "methodreturn",
+  "include": ["temp.h"],
+  "libs":"$(pkg-config --libs xxx)",
+  "cplusplus":false
+}

--- a/cmd/gogensig/convert/_testdata/methodreturn/conf/llcppg.symb.json
+++ b/cmd/gogensig/convert/_testdata/methodreturn/conf/llcppg.symb.json
@@ -1,0 +1,7 @@
+[
+  {
+    "mangle": "Vector3Barycenter",
+    "c++": "Vector3Barycenter(Vector3, Vector3, Vector3, Vector3)",
+    "go": "Vector3.Vector3Barycenter"
+  }
+]

--- a/cmd/gogensig/convert/_testdata/methodreturn/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/methodreturn/gogensig.expect
@@ -1,0 +1,32 @@
+===== methodreturn_autogen_link.go =====
+package methodreturn
+
+import _ "github.com/goplus/llgo/c"
+
+const LLGoPackage string = "link: $(pkg-config --libs xxx);"
+
+===== temp.go =====
+package methodreturn
+
+import (
+	"github.com/goplus/llgo/c"
+	_ "unsafe"
+)
+
+// origin field is float,but if use float,we will ref the c.Float
+// we only can get the c.Float's underlying type,not the c.Float
+// so we use int to replace float, https://github.com/goplus/llcppg/issues/249
+type Vector3 struct {
+	X c.Int
+	Y c.Int
+	Z c.Int
+}
+
+// in the case we want to check the return type is a zero named struct type,not a anonymous struct type
+// llgo:link Vector3.Vector3Barycenter C.Vector3Barycenter
+func (recv_ Vector3) Vector3Barycenter(a Vector3, b Vector3, c Vector3) Vector3 {
+	return Vector3{}
+}
+
+===== llcppg.pub =====
+Vector3

--- a/cmd/gogensig/convert/_testdata/methodreturn/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/methodreturn/hfile/temp.h
@@ -1,0 +1,11 @@
+// origin field is float,but if use float,we will ref the c.Float
+// we only can get the c.Float's underlying type,not the c.Float
+// so we use int to replace float, https://github.com/goplus/llcppg/issues/249
+typedef struct Vector3 {
+    int x;
+    int y;
+    int z;
+} Vector3;
+
+// in the case we want to check the return type is a zero named struct type,not a anonymous struct type
+Vector3 Vector3Barycenter(Vector3 p, Vector3 a, Vector3 b, Vector3 c);

--- a/cmd/gogensig/convert/package.go
+++ b/cmd/gogensig/convert/package.go
@@ -197,6 +197,21 @@ func (p *Package) bodyStart(decl *gogen.Func, ret ast.Expr) error {
 		if err != nil {
 			return err
 		}
+
+		if asStruct(retType) {
+			// use empty named struct type to return,without this solution,we will get a anonymous struct type
+			// and it will cause a compile error,like following:
+			// func (recv *Vector3) Vector3Barycenter(p Vector3, a Vector3, b Vector3, c Vector3) Vector3 {
+			// 	return struct {
+			// 		x c.Int
+			// 		y c.Int
+			// 		z c.Int
+			// 	}{}
+			// }
+			// this result will cause the `c` in the return type is use the `c` in the parameter,which is not have the `Int`
+			decl.BodyStart(p.p).StructLit(retType, 0, true).Return(1).End()
+			return nil
+		}
 		decl.BodyStart(p.p).ZeroLit(retType).Return(1).End()
 	} else {
 		decl.BodyStart(p.p).End()

--- a/cmd/gogensig/convert/type.go
+++ b/cmd/gogensig/convert/type.go
@@ -361,6 +361,18 @@ func avoidKeyword(name string) string {
 	return name
 }
 
+func asStruct(typ types.Type) bool {
+	switch t := typ.(type) {
+	case *types.Named:
+		return asStruct(t.Underlying())
+	case *types.Alias:
+		return asStruct(types.Unalias(t))
+	case *types.Struct:
+		return true
+	}
+	return false
+}
+
 func substObj(pkg *types.Package, scope *types.Scope, origName string, real types.Object) {
 	old := scope.Insert(gogen.NewSubst(token.NoPos, pkg, origName, real))
 	if old != nil {


### PR DESCRIPTION
support https://github.com/goplus/llcppg/pull/244

without this solution,will got follow situation.

![image](https://github.com/user-attachments/assets/3d8d79a0-c686-4926-822b-3aa91e76451f)

this result will cause the `c` in the return type is use the `c` in the parameter,which is not have the `Int`