### PR TITLE
gogensig/chore:remove complete todo comment

### DIFF
--- a/cmd/gogensig/convert/_testdata/receiver/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/receiver/gogensig.expect
@@ -38,8 +38,6 @@ import (
 	_ "unsafe"
 )
 
-// todo(zzy): ares_addr need generate in the temp.go
-//
 //go:linkname AresDnsPton C.ares_dns_pton
 func AresDnsPton(ipaddr *c.Char, addr *AresAddr) c.Pointer
 

--- a/cmd/gogensig/convert/_testdata/receiver/hfile/use.h
+++ b/cmd/gogensig/convert/_testdata/receiver/hfile/use.h
@@ -1,3 +1,2 @@
-// todo(zzy): ares_addr need generate in the temp.go
 const void *ares_dns_pton(const char *ipaddr, struct ares_addr *addr);
 char *ares_dns_addr_to_ptr(const struct ares_addr *addr);


### PR DESCRIPTION
in `cmd/gogensig/convert/_testdata/receiver/gogensig.expect.`
the `ares_addr` has gen in the temp.go