### PR TITLE
gogensig:panic when func name used & skip processed node

### DIFF
--- a/_xtool/llcppsymg/_cmptest/names_test/names.go
+++ b/_xtool/llcppsymg/_cmptest/names_test/names.go
@@ -44,27 +44,38 @@ func TestToGoName() {
 func TestNameMapper() {
 	fmt.Println("=== Test NameMapper ===")
 
+	toCamel := func(trimprefix []string) names.NameMethod {
+		return func(name string) string {
+			return names.PubName(names.RemovePrefixedName(name, trimprefix))
+		}
+	}
+	toExport := func(trimprefix []string) names.NameMethod {
+		return func(name string) string {
+			return names.ExportName(names.RemovePrefixedName(name, trimprefix))
+		}
+	}
+
 	mapper := names.NewNameMapper()
 	testCases := []struct {
 		name         string
 		trimPrefixes []string
-		toCamel      bool
+		nameMethod   func(trimprefix []string) names.NameMethod
 		expected     string
 		expectChange bool
 	}{
-		{"lua_closethread", []string{"lua_", "luaL_"}, true, "Closethread", true},
-		{"luaL_checknumber", []string{"lua_", "luaL_"}, true, "Checknumber", true},
-		{"_gmp_err", []string{}, true, "X_gmpErr", true},
-		{"fn_123illegal", []string{"fn_"}, true, "X123illegal", true},
-		{"fts5_tokenizer", []string{}, true, "Fts5Tokenizer", true},
-		{"Fts5Tokenizer", []string{}, true, "Fts5Tokenizer__1", true},
-		{"normal_var", []string{}, false, "Normal_var", true},
-		{"Cameled", []string{}, false, "Cameled", false},
+		{"lua_closethread", []string{"lua_", "luaL_"}, toCamel, "Closethread", true},
+		{"luaL_checknumber", []string{"lua_", "luaL_"}, toCamel, "Checknumber", true},
+		{"_gmp_err", []string{}, toCamel, "X_gmpErr", true},
+		{"fn_123illegal", []string{"fn_"}, toCamel, "X123illegal", true},
+		{"fts5_tokenizer", []string{}, toCamel, "Fts5Tokenizer", true},
+		{"Fts5Tokenizer", []string{}, toCamel, "Fts5Tokenizer__1", true},
+		{"normal_var", []string{}, toExport, "Normal_var", true},
+		{"Cameled", []string{}, toExport, "Cameled", false},
 	}
 
 	fmt.Println("\nTesting GetUniqueGoName:")
 	for _, tc := range testCases {
-		result, changed := mapper.GetUniqueGoName(tc.name, tc.trimPrefixes, tc.toCamel)
+		result, changed := mapper.GetUniqueGoName(tc.name, tc.nameMethod(tc.trimPrefixes))
 		if result != tc.expected || changed != tc.expectChange {
 			fmt.Printf("Input: %s, Expected: %s %t, Got: %s %t\n", tc.name, tc.expected, tc.expectChange, result, changed)
 		} else {

--- a/_xtool/llcppsymg/names/names.go
+++ b/_xtool/llcppsymg/names/names.go
@@ -20,37 +20,32 @@ func NewNameMapper() *NameMapper {
 	}
 }
 
+type NameMethod func(name string) string
+
 // returns a unique Go name for an original name
 // For every go name, it will be unique.
-func (m *NameMapper) GetUniqueGoName(name string, trimPrefixes []string, toCamel bool) (string, bool) {
-	pubName, exist := m.genGoName(name, trimPrefixes, toCamel)
+func (m *NameMapper) GetUniqueGoName(name string, nameMethod NameMethod) (pubName string, changed bool) {
+	pubName, exist := m.genGoName(name, nameMethod)
 	if exist {
 		return pubName, pubName != name
 	}
 
-	count := m.count[pubName]
 	m.count[pubName]++
-	if count > 0 {
-		pubName = fmt.Sprintf("%s__%d", pubName, count)
-	}
+	count := m.count[pubName]
+	pubName = SuffixCount(pubName, count)
 
 	return pubName, pubName != name
 }
 
 // returns the Go name for an original name,if the name is already mapped,return the mapped name
-func (m *NameMapper) genGoName(name string, trimPrefixes []string, toCamel bool) (string, bool) {
+func (m *NameMapper) genGoName(name string, nameMethod NameMethod) (string, bool) {
 	if goName, exists := m.mapping[name]; exists {
 		if goName == "" {
 			return name, true
 		}
 		return goName, true
 	}
-	name = removePrefixedName(name, trimPrefixes)
-	if toCamel {
-		return PubName(name), false
-	} else {
-		return ExportName(name), false
-	}
+	return nameMethod(name), false
 }
 
 func (m *NameMapper) SetMapping(originName, newName string) {
@@ -61,14 +56,18 @@ func (m *NameMapper) SetMapping(originName, newName string) {
 	m.mapping[originName] = value
 }
 
+func (m *NameMapper) Lookup(name string) int {
+	return m.count[name]
+}
+
 func GoName(name string, trimPrefixes []string, inCurPkg bool) string {
 	if inCurPkg {
-		name = removePrefixedName(name, trimPrefixes)
+		name = RemovePrefixedName(name, trimPrefixes)
 	}
 	return PubName(name)
 }
 
-func removePrefixedName(name string, trimPrefixes []string) string {
+func RemovePrefixedName(name string, trimPrefixes []string) string {
 	if len(trimPrefixes) == 0 {
 		return name
 	}
@@ -145,4 +144,11 @@ func HeaderFileToGo(incPath string) string {
 		fileName = "X" + fileName
 	}
 	return fileName + ".go"
+}
+
+func SuffixCount(name string, count int) string {
+	if count > 1 {
+		return fmt.Sprintf("%s__%d", name, count-1)
+	}
+	return name
 }

--- a/_xtool/llcppsymg/names/names.go
+++ b/_xtool/llcppsymg/names/names.go
@@ -56,10 +56,6 @@ func (m *NameMapper) SetMapping(originName, newName string) {
 	m.mapping[originName] = value
 }
 
-func (m *NameMapper) Lookup(name string) int {
-	return m.count[name]
-}
-
 func GoName(name string, trimPrefixes []string, inCurPkg bool) string {
 	if inCurPkg {
 		name = RemovePrefixedName(name, trimPrefixes)

--- a/cmd/gogensig/convert/_testdata/gettext/conf/llcppg.cfg
+++ b/cmd/gogensig/convert/_testdata/gettext/conf/llcppg.cfg
@@ -1,0 +1,12 @@
+{
+	"name": "gettext",
+	"libs": "$(pkg-config --libs xxx)",
+	"include": [
+		"gettext-po.h"
+	],
+	"typeMap": {
+		"po_message_iterator": "MessageIteratorType"
+	},
+	"trimPrefixes": ["po_"],
+	"cplusplus": false
+}

--- a/cmd/gogensig/convert/_testdata/gettext/conf/llcppg.symb.json
+++ b/cmd/gogensig/convert/_testdata/gettext/conf/llcppg.symb.json
@@ -1,0 +1,7 @@
+[
+  {
+    "mangle": "po_message_iterator",
+    "c++": "po_message_iterator(po_file_t, const char *)",
+    "go": "MessageIterator"
+  }
+]

--- a/cmd/gogensig/convert/_testdata/gettext/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/gettext/gogensig.expect
@@ -1,0 +1,35 @@
+===== gettext-po.go =====
+package gettext
+
+import (
+	"github.com/goplus/lib/c"
+	_ "unsafe"
+)
+
+type File struct {
+	Unused [8]uint8
+}
+type FileT *File
+
+type MessageIteratorType struct {
+	Unused [8]uint8
+}
+type MessageIteratorT *MessageIteratorType
+
+/* Create an iterator for traversing a domain of a PO file in memory.
+   The domain NULL denotes the default domain.  */
+//go:linkname MessageIterator C.po_message_iterator
+func MessageIterator(file FileT, domain *c.Char) MessageIteratorT
+
+===== gettext_autogen_link.go =====
+package gettext
+
+import _ "github.com/goplus/lib/c"
+
+const LLGoPackage string = "link: $(pkg-config --libs xxx);"
+
+===== llcppg.pub =====
+po_file File
+po_file_t FileT
+po_message_iterator MessageIteratorType
+po_message_iterator_t MessageIteratorT

--- a/cmd/gogensig/convert/_testdata/gettext/hfile/gettext-po.h
+++ b/cmd/gogensig/convert/_testdata/gettext/hfile/gettext-po.h
@@ -1,0 +1,8 @@
+/* A po_file_t represents the contents of a PO file.  */
+typedef struct po_file *po_file_t;
+/* A po_message_iterator_t represents an iterator through a domain of a
+   PO file.  */
+typedef struct po_message_iterator *po_message_iterator_t;
+/* Create an iterator for traversing a domain of a PO file in memory.
+   The domain NULL denotes the default domain.  */
+extern po_message_iterator_t po_message_iterator (po_file_t file, const char *domain);

--- a/cmd/gogensig/convert/_testdata/lua/conf/llcppg.cfg
+++ b/cmd/gogensig/convert/_testdata/lua/conf/llcppg.cfg
@@ -3,5 +3,8 @@
   "include": ["lua.h","luaconf.h","lauxlib.h","lualib.h"],
   "trimPrefixes": ["luaopen_","luaL_","lua_","lua","LUA_"],
   "libs":"$(pkg-config --libs lua)",
-  "cplusplus":false
+  "cplusplus":false,
+  "typeMap":{
+    "lua_Debug":"DebugT"
+  }
 }

--- a/cmd/gogensig/convert/_testdata/lua/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/lua/gogensig.expect
@@ -684,6 +684,9 @@ func Utf8(L *State) c.Int
 //go:linkname Math C.luaopen_math
 func Math(L *State) c.Int
 
+//go:linkname Debug__1 C.luaopen_debug
+func Debug__1(L *State) c.Int
+
 //go:linkname Package C.luaopen_package
 func Package(L *State) c.Int
 

--- a/cmd/gogensig/convert/_testdata/lua/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/lua/gogensig.expect
@@ -259,7 +259,7 @@ type Alloc func(c.Pointer, c.Pointer, c.SizeT, c.SizeT) c.Pointer
 // llgo:type C
 type WarnFunction func(c.Pointer, *c.Char, c.Int)
 
-type Debug struct {
+type DebugT struct {
 	Event           c.Int
 	Name            *c.Char
 	Namewhat        *c.Char
@@ -280,7 +280,7 @@ type Debug struct {
 }
 
 // llgo:type C
-type Hook func(*State, *Debug)
+type Hook func(*State, *DebugT)
 
 /*
 ** state manipulation
@@ -568,16 +568,16 @@ func Toclose(L *State, idx c.Int)
 func Closeslot(L *State, idx c.Int)
 
 //go:linkname Getstack C.lua_getstack
-func Getstack(L *State, level c.Int, ar *Debug) c.Int
+func Getstack(L *State, level c.Int, ar *DebugT) c.Int
 
 //go:linkname Getinfo C.lua_getinfo
-func Getinfo(L *State, what *c.Char, ar *Debug) c.Int
+func Getinfo(L *State, what *c.Char, ar *DebugT) c.Int
 
 //go:linkname Getlocal C.lua_getlocal
-func Getlocal(L *State, ar *Debug, n c.Int) *c.Char
+func Getlocal(L *State, ar *DebugT, n c.Int) *c.Char
 
 //go:linkname Setlocal C.lua_setlocal
-func Setlocal(L *State, ar *Debug, n c.Int) *c.Char
+func Setlocal(L *State, ar *DebugT, n c.Int) *c.Char
 
 //go:linkname Getupvalue C.lua_getupvalue
 func Getupvalue(L *State, funcindex c.Int, n c.Int) *c.Char
@@ -684,8 +684,8 @@ func Utf8(L *State) c.Int
 //go:linkname Math C.luaopen_math
 func Math(L *State) c.Int
 
-//go:linkname Debug__1 C.luaopen_debug
-func Debug__1(L *State) c.Int
+//go:linkname Debug C.luaopen_debug
+func Debug(L *State) c.Int
 
 //go:linkname Package C.luaopen_package
 func Package(L *State) c.Int
@@ -700,7 +700,7 @@ luaL_Reg Reg
 luaL_Stream Stream
 lua_Alloc Alloc
 lua_CFunction CFunction
-lua_Debug Debug
+lua_Debug DebugT
 lua_Hook Hook
 lua_Integer Integer
 lua_KContext KContext

--- a/cmd/gogensig/convert/_testdata/redefine/conf/llcppg.cfg
+++ b/cmd/gogensig/convert/_testdata/redefine/conf/llcppg.cfg
@@ -1,0 +1,7 @@
+{
+  "name": "redefine",
+  "include": ["temp.h"],
+  "libs": "$(pkg-config --libs xxx)",
+  "cplusplus":false,
+  "trimPrefixes": ["Prefix1_","Prefix2_","Prefix3_","Prefix4_","Prefix5_"]
+}

--- a/cmd/gogensig/convert/_testdata/redefine/conf/llcppg.symb.json
+++ b/cmd/gogensig/convert/_testdata/redefine/conf/llcppg.symb.json
@@ -1,0 +1,7 @@
+[
+  {
+    "mangle": "Prefix5_tokenizer",
+    "c++": "Prefix5_tokenizer",
+    "go": "TokenizerFn"
+  }
+]

--- a/cmd/gogensig/convert/_testdata/redefine/gogensig.expect
+++ b/cmd/gogensig/convert/_testdata/redefine/gogensig.expect
@@ -1,0 +1,39 @@
+===== redefine_autogen_link.go =====
+package redefine
+
+import _ "github.com/goplus/lib/c"
+
+const LLGoPackage string = "link: $(pkg-config --libs xxx);"
+
+===== temp.go =====
+package redefine
+
+import (
+	"github.com/goplus/lib/c"
+	_ "unsafe"
+)
+
+const Tokenizer = "tokenizer"
+
+type Tokenizer__1 struct {
+	Unused [8]uint8
+}
+
+type Tokenizer__2 struct {
+	Unused [8]uint8
+}
+type Tokenizer__3 c.Int
+
+const (
+	Red    Tokenizer__3 = 0
+	Orange Tokenizer__3 = 1
+	Yellow Tokenizer__3 = 2
+)
+
+//go:linkname TokenizerFn C.Prefix5_tokenizer
+func TokenizerFn(a c.Long)
+
+===== llcppg.pub =====
+Prefix2_Tokenizer Tokenizer__1
+Prefix3_tokenizer Tokenizer__2
+Prefix4_tokenizer Tokenizer__3

--- a/cmd/gogensig/convert/_testdata/redefine/hfile/temp.h
+++ b/cmd/gogensig/convert/_testdata/redefine/hfile/temp.h
@@ -1,0 +1,5 @@
+#define Prefix1_tokenizer "tokenizer"
+struct Prefix2_Tokenizer;
+typedef struct Prefix3_tokenizer Prefix3_tokenizer;
+enum Prefix4_tokenizer { red, orange, yellow };
+void Prefix5_tokenizer(long a);

--- a/cmd/gogensig/convert/package.go
+++ b/cmd/gogensig/convert/package.go
@@ -342,9 +342,8 @@ func (p *Package) funcIsDefined(fnSpec *GoFuncSpec, funcDecl *ast.FuncDecl) (rec
 		recv = p.newReceiver(funcDecl.Type)
 		var namedType = getNamedType(recv.Type())
 		methodName := fnSpec.FnName
-		// todo(zzy): check if the method name is already processed
 		for i := 0; i < namedType.NumMethods(); i++ {
-			if namedType.Method(i).Name() == methodName {
+			if namedType.Method(i).Name() == methodName { // unreachable,because if have the same method name,will return in p.symbols.Lookup(node)
 				return nil, true, errs.NewFuncAlreadyDefinedError(fnSpec.GoSymbName)
 			}
 		}
@@ -385,7 +384,6 @@ func (p *Package) NewTypeDecl(typeDecl *ast.TypeDecl) error {
 	isForward := p.cvt.inComplete(typeDecl.Type)
 	name, changed, exist, err := p.RegisterNode(Node{name: cname, kind: TypeDecl}, p.declName)
 	if err != nil {
-		// todo(zzy):panic when register error
 		return err
 	}
 

--- a/cmd/gogensig/convert/package_test.go
+++ b/cmd/gogensig/convert/package_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/goplus/llcppg/cmd/gogensig/convert"
 	"github.com/goplus/llcppg/cmd/gogensig/dbg"
 	"github.com/goplus/llcppg/llcppg"
+	"github.com/goplus/llcppg/token"
 	"github.com/goplus/mod/gopmod"
 )
 
@@ -1243,11 +1244,6 @@ func TestRedef(t *testing.T) {
 		t.Fatal("unexpect redefine err")
 	}
 
-	pkg.NewTypedefDecl(&ast.TypedefDecl{
-		Name: &ast.Ident{Name: "Foo"},
-		Type: &ast.Ident{Name: "Foo"},
-	})
-
 	err = pkg.NewFuncDecl(&ast.FuncDecl{
 		Name:        &ast.Ident{Name: "Bar"},
 		MangledName: "Bar",
@@ -1292,6 +1288,35 @@ func TestRedef(t *testing.T) {
 		t.Fatal("Expect a redefine err")
 	}
 
+	err = pkg.NewEnumTypeDecl(&ast.EnumTypeDecl{
+		Name: &ast.Ident{Name: "EnumFoo"},
+		Type: &ast.EnumType{
+			Items: []*ast.EnumItem{
+				{Name: &ast.Ident{Name: "ItemBar"}, Value: &ast.BasicLit{Kind: ast.IntLit, Value: "0"}},
+				{Name: &ast.Ident{Name: "ItemBar"}, Value: &ast.BasicLit{Kind: ast.IntLit, Value: "1"}},
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatal("unexpect err")
+	}
+
+	macro := &ast.Macro{
+		Loc:    &ast.Location{File: tempFile.File},
+		Name:   "MACRO_FOO",
+		Tokens: []*ast.Token{{Token: token.IDENT, Lit: "MACRO_FOO"}, {Token: token.LITERAL, Lit: "1"}},
+	}
+	err = pkg.NewMacro(macro)
+	if err != nil {
+		t.Fatal("unexpect redefine err")
+	}
+
+	err = pkg.NewMacro(macro)
+	if err != nil {
+		t.Fatal("unexpect redefine err")
+	}
+
 	var buf bytes.Buffer
 	err = pkg.GetGenPackage().WriteTo(&buf)
 	if err != nil {
@@ -1311,8 +1336,44 @@ type Foo struct {
 }
 //go:linkname Bar C.Bar
 func Bar()
+
+type EnumFoo c.Int
+const ItemBar EnumFoo = 0
+const MACRO_FOO = 1
 `
 	comparePackageOutput(t, pkg, expect)
+}
+
+func TestRedefineFunc(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected Panic")
+		}
+	}()
+	pkg := createTestPkg(t, &convert.PackageConfig{
+		SymbolTable: config.CreateSymbolTable(
+			[]config.SymbolEntry{
+				{CppName: "Foo", MangleName: "Foo", GoName: "Foo"},
+			},
+		),
+	})
+	pkg.SetCurFile(tempFile)
+
+	err := pkg.NewTypeDecl(&ast.TypeDecl{
+		Name: &ast.Ident{Name: "Foo"},
+		Type: &ast.RecordType{
+			Tag:    ast.Struct,
+			Fields: &ast.FieldList{},
+		},
+	})
+	if err != nil {
+		t.Fatal("NewTypeDecl failed", err)
+	}
+	pkg.NewFuncDecl(&ast.FuncDecl{
+		Name:        &ast.Ident{Name: "Foo"},
+		MangledName: "Foo",
+		Type:        &ast.FuncType{},
+	})
 }
 
 func TestTypedef(t *testing.T) {

--- a/cmd/gogensig/convert/package_test.go
+++ b/cmd/gogensig/convert/package_test.go
@@ -1239,8 +1239,8 @@ func TestRedef(t *testing.T) {
 			Fields: flds,
 		},
 	})
-	if err == nil {
-		t.Fatal("Expect a redefine err")
+	if err != nil {
+		t.Fatal("unexpect redefine err")
 	}
 
 	pkg.NewTypedefDecl(&ast.TypedefDecl{
@@ -1266,8 +1266,8 @@ func TestRedef(t *testing.T) {
 		MangledName: "Bar",
 		Type:        &ast.FuncType{},
 	})
-	if err == nil {
-		t.Fatal("Expect a redefine err")
+	if err != nil {
+		t.Fatal("unexpect redefine err")
 	}
 
 	err = pkg.NewEnumTypeDecl(&ast.EnumTypeDecl{


### PR DESCRIPTION
* 为了批处理的正确，优先保证对于重复命名的函数panic。
*  为了让panic正常运行，并且ci正常通过, _llcppgtest 存在用例gpgerror,这个库中存在两个几乎相同的头文件，并且没有头文件守卫，也就是对于一个头文件中会出现多个相同名称的节点，这在当前逻辑以及Go语法中是不允许的，但是在C语言中是允许的，所以为了让重复命名的函数正确panic，以及对于以下用例，能正常的通过编译，于是将经过处理的节点收集起来，阻止反复处理。
  
gpg-error.h
```c
/* The error value type gpg_error_t.  */

/* We would really like to use bit-fields in a struct, but using
 * structs as return values can cause binary compatibility issues, in
 * particular if you want to do it efficiently (also see
 * -freg-struct-return option to GCC).  */
typedef unsigned int gpg_error_t;

/* We use the lowest 16 bits of gpg_error_t for error codes.  The 16th
 * bit indicates system errors.  */
#define GPG_ERR_CODE_MASK	(GPG_ERR_CODE_DIM - 1)
```
gpgrt.h
```c

/* The error value type gpg_error_t.  */

/* We would really like to use bit-fields in a struct, but using
 * structs as return values can cause binary compatibility issues, in
 * particular if you want to do it efficiently (also see
 * -freg-struct-return option to GCC).  */
typedef unsigned int gpg_error_t;

/* We use the lowest 16 bits of gpg_error_t for error codes.  The 16th
 * bit indicates system errors.  */
#define GPG_ERR_CODE_MASK	(GPG_ERR_CODE_DIM - 1)
```
* 后续PR去支持函数重复命名后,增加__x,并可以保证向后兼容。


