### PR TITLE
llcppsigfetch:skip typedef multi-level self-references

### DIFF
--- a/_xtool/llcppsigfetch/parse/cvt_test/decl_test/typedef_test/llgo.expect
+++ b/_xtool/llcppsigfetch/parse/cvt_test/decl_test/typedef_test/llgo.expect
@@ -1117,6 +1117,79 @@ TestTypeDefDecl Case 12:
 	}
 }
 
+TestTypeDefDecl Case 13:
+{
+	"File":	{
+		"_Type":	"File",
+		"decls":	[{
+				"_Type":	"EnumTypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"algorithm"
+				},
+				"Type":	{
+					"_Type":	"EnumType",
+					"Items":	[{
+							"_Type":	"EnumItem",
+							"Name":	{
+								"_Type":	"Ident",
+								"Name":	"A"
+							},
+							"Value":	{
+								"_Type":	"BasicLit",
+								"Kind":	0,
+								"Value":	"0"
+							}
+						}, {
+							"_Type":	"EnumItem",
+							"Name":	{
+								"_Type":	"Ident",
+								"Name":	"B"
+							},
+							"Value":	{
+								"_Type":	"BasicLit",
+								"Kind":	0,
+								"Value":	"1"
+							}
+						}]
+				}
+			}, {
+				"_Type":	"TypedefDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"algorithm_t"
+				},
+				"Type":	{
+					"_Type":	"TagExpr",
+					"Name":	{
+						"_Type":	"Ident",
+						"Name":	"algorithm"
+					},
+					"Tag":	2
+				}
+			}],
+		"includes":	[],
+		"macros":	[]
+	},
+	"FileMap":	{
+		"temp.h":	{
+			"FileType":	1
+		}
+	}
+}
+
 
 #stderr
 

--- a/_xtool/llcppsigfetch/parse/cvt_test/decl_test/typedef_test/typedef.go
+++ b/_xtool/llcppsigfetch/parse/cvt_test/decl_test/typedef_test/typedef.go
@@ -54,6 +54,12 @@ func TestTypeDefDecl() {
 				} MyStruct,MyStruct2,*StructPtr, StructArr[];
 			}
 		}`,
+
+		`typedef enum algorithm {
+			A,
+			B
+		} algorithm_t;
+		typedef algorithm_t algorithm;`,
 	}
 	test.RunTest("TestTypeDefDecl", testCases)
 }

--- a/cmd/gogensig/convert/package_test.go
+++ b/cmd/gogensig/convert/package_test.go
@@ -1257,6 +1257,14 @@ func TestRedef(t *testing.T) {
 		t.Fatal("NewFuncDecl failed", err)
 	}
 
+	err = pkg.NewTypedefDecl(&ast.TypedefDecl{
+		Name: &ast.Ident{Name: "Bar"},
+		Type: &ast.Ident{Name: "Bar"},
+	})
+	if err == nil {
+		t.Fatal("expect a redefine err")
+	}
+
 	err = pkg.NewFuncDecl(&ast.FuncDecl{
 		Name:        &ast.Ident{Name: "Bar"},
 		MangledName: "Bar",


### PR DESCRIPTION
This PR fixes a bug that caused panics during typedef name processing with multi-level typedef chains where a typedef ultimately refers back to the original declaration name through intermediate typedefs.

### Problem
Previously, the code only detected direct self-references in typedefs (e.g., `typedef struct Foo Foo;`), but failed to detect cases where the reference occurred through one or more intermediate typedefs:

```c
typedef enum algorithm {
    UNKNOWN = 0,
    NULL = 1,
} algorithm_t;

typedef algorithm_t algorithm;  // This causes a panic when processed
```

When processing typedef algorithm_t algorithm;, the system didn't recognize that algorithm_t eventually refers to enum algorithm, leading to duplicate definitions and causing a panic in subsequent processing phases.

### Solution

Added a new recursive function getActualTypeCursor that traverses typedef chains to find the original declaration type. This enables the system to detect when a typedef ultimately refers back to a type with the same name, even through multiple levels of indirection.
The solution now correctly handles:
1. Direct self-references: `typedef struct Foo Foo;`
2. Indirect self-references: `typedef enum Bar {...} Bar_t;` `typedef Bar_t Bar;`
With this fix, the system properly filters out redundant typedef declarations that would otherwise cause namespace collisions and panics.