### PR TITLE
gogensig/refactor:collect name map by node

### DIFF
--- a/_xtool/llcppsymg/_cmptest/names_test/llgo.expect
+++ b/_xtool/llcppsymg/_cmptest/names_test/llgo.expect
@@ -8,17 +8,6 @@ Before: GetReal After: GetReal
 Before: GetBoolean After: GetBoolean
 Before: INIReader After: Reader
 
-=== Test NameMapper ===
-
-Testing GetUniqueGoName:
-Input: lua_closethread, Output: Closethread true
-Input: luaL_checknumber, Output: Checknumber true
-Input: _gmp_err, Output: X_gmpErr true
-Input: fn_123illegal, Output: X123illegal true
-Input: fts5_tokenizer, Output: Fts5Tokenizer true
-Input: Fts5Tokenizer, Output: Fts5Tokenizer__1 true
-Input: normal_var, Output: Normal_var true
-Input: Cameled, Output: Cameled false
 
 === Test PubName ===
 Input: sqlite_file, Output: SqliteFile

--- a/_xtool/llcppsymg/_cmptest/names_test/names.go
+++ b/_xtool/llcppsymg/_cmptest/names_test/names.go
@@ -9,7 +9,6 @@ import (
 
 func main() {
 	TestToGoName()
-	TestNameMapper()
 	TestPubName()
 	TestExportName()
 	TestHeaderFileToGo()
@@ -39,49 +38,6 @@ func TestToGoName() {
 		fmt.Printf("Before: %s After: %s\n", tc.input, result)
 	}
 	fmt.Println()
-}
-
-func TestNameMapper() {
-	fmt.Println("=== Test NameMapper ===")
-
-	toCamel := func(trimprefix []string) names.NameMethod {
-		return func(name string) string {
-			return names.PubName(names.RemovePrefixedName(name, trimprefix))
-		}
-	}
-	toExport := func(trimprefix []string) names.NameMethod {
-		return func(name string) string {
-			return names.ExportName(names.RemovePrefixedName(name, trimprefix))
-		}
-	}
-
-	mapper := names.NewNameMapper()
-	testCases := []struct {
-		name         string
-		trimPrefixes []string
-		nameMethod   func(trimprefix []string) names.NameMethod
-		expected     string
-		expectChange bool
-	}{
-		{"lua_closethread", []string{"lua_", "luaL_"}, toCamel, "Closethread", true},
-		{"luaL_checknumber", []string{"lua_", "luaL_"}, toCamel, "Checknumber", true},
-		{"_gmp_err", []string{}, toCamel, "X_gmpErr", true},
-		{"fn_123illegal", []string{"fn_"}, toCamel, "X123illegal", true},
-		{"fts5_tokenizer", []string{}, toCamel, "Fts5Tokenizer", true},
-		{"Fts5Tokenizer", []string{}, toCamel, "Fts5Tokenizer__1", true},
-		{"normal_var", []string{}, toExport, "Normal_var", true},
-		{"Cameled", []string{}, toExport, "Cameled", false},
-	}
-
-	fmt.Println("\nTesting GetUniqueGoName:")
-	for _, tc := range testCases {
-		result, changed := mapper.GetUniqueGoName(tc.name, tc.nameMethod(tc.trimPrefixes))
-		if result != tc.expected || changed != tc.expectChange {
-			fmt.Printf("Input: %s, Expected: %s %t, Got: %s %t\n", tc.name, tc.expected, tc.expectChange, result, changed)
-		} else {
-			fmt.Printf("Input: %s, Output: %s %t\n", tc.name, result, changed)
-		}
-	}
 }
 
 func TestPubName() {

--- a/_xtool/llcppsymg/names/names.go
+++ b/_xtool/llcppsymg/names/names.go
@@ -7,55 +7,6 @@ import (
 	"unicode"
 )
 
-// NameMapper handles name mapping and uniqueness for Go symbols
-type NameMapper struct {
-	count   map[string]int    // tracks count of each public name for uniqueness
-	mapping map[string]string // maps original c names to Go names,like: foo(in c) -> Foo(in go)
-}
-
-func NewNameMapper() *NameMapper {
-	return &NameMapper{
-		count:   make(map[string]int),
-		mapping: make(map[string]string),
-	}
-}
-
-type NameMethod func(name string) string
-
-// returns a unique Go name for an original name
-// For every go name, it will be unique.
-func (m *NameMapper) GetUniqueGoName(name string, nameMethod NameMethod) (pubName string, changed bool) {
-	pubName, exist := m.genGoName(name, nameMethod)
-	if exist {
-		return pubName, pubName != name
-	}
-
-	m.count[pubName]++
-	count := m.count[pubName]
-	pubName = SuffixCount(pubName, count)
-
-	return pubName, pubName != name
-}
-
-// returns the Go name for an original name,if the name is already mapped,return the mapped name
-func (m *NameMapper) genGoName(name string, nameMethod NameMethod) (string, bool) {
-	if goName, exists := m.mapping[name]; exists {
-		if goName == "" {
-			return name, true
-		}
-		return goName, true
-	}
-	return nameMethod(name), false
-}
-
-func (m *NameMapper) SetMapping(originName, newName string) {
-	value := ""
-	if originName != newName {
-		value = newName
-	}
-	m.mapping[originName] = value
-}
-
 func GoName(name string, trimPrefixes []string, inCurPkg bool) string {
 	if inCurPkg {
 		name = RemovePrefixedName(name, trimPrefixes)

--- a/cmd/gogensig/convert/package.go
+++ b/cmd/gogensig/convert/package.go
@@ -872,7 +872,7 @@ func (p *Package) definedName(name string) (string, bool) {
 //
 // Returns:
 //   - Transformed identifier name
-func (p *Package) transformName(name string, transform func(string) string) string {
+func (p *Package) transformName(name string, transform NameMethod) string {
 	if definedName, ok := p.definedName(name); ok {
 		return definedName
 	}


### PR DESCRIPTION
1. Integrate name mapping into ProcessSymbol:

* The new system uses Node (including name and type) as the key to ensure that struct foo and typedef foo are treated as distinct entities.

* A map[Node]string is used to store the mapping from each node to its generated name, ensuring unique names for nodes with the same name but different types.

2. Remove the standalone nameMapper:

* nameMapper has limitations and cannot distinguish between nodes with the same name but different types.

--- 

1. 将命名映射集成到ProcessSymbol：
* 新系统使用Node(包含名称和类型)作为键，确保struct foo和typedef foo被视为不同实体
* 通过map[Node]string存储节点到生成名称的映射，为同名不同类型节点生成唯一名称
2. 移除独立的nameMapper：
* nameMapper 存在局限性，无法区分不同类型节点的同名情况