### PR TITLE
gogensig:lookup origin name for type decl

### DIFF
--- a/cmd/gogensig/convert/package.go
+++ b/cmd/gogensig/convert/package.go
@@ -355,6 +355,20 @@ func (p *Package) Lookup(name string) types.Object {
 	return gogen.Lookup(p.p.Types.Scope(), name)
 }
 
+func (p *Package) lookupOrigin(name string, pubName string) types.Object {
+	if obj := p.Lookup(name); obj != nil {
+		return obj
+	}
+	if name != pubName {
+		return p.Lookup(pubName)
+	}
+	return nil
+}
+
+func (p *Package) lookupPub(name string, pubName string) types.Object {
+	return p.Lookup(pubName)
+}
+
 // NewTypeDecl converts C/C++ type declarations to Go.
 // Besides regular type declarations, it also supports:
 // - Forward declarations: Pre-registers incomplete types for later definition
@@ -376,7 +390,7 @@ func (p *Package) NewTypeDecl(typeDecl *ast.TypeDecl) error {
 
 	cname := typeDecl.Name.Name
 	isForward := p.cvt.inComplete(typeDecl.Type)
-	name, changed, exist, err := p.RegisterNode(Node{name: cname, kind: TypeDecl}, p.declName)
+	name, changed, exist, err := p.RegisterNode(Node{name: cname, kind: TypeDecl}, p.declName, p.lookupOrigin)
 	if err != nil {
 		return err
 	}
@@ -448,7 +462,7 @@ func (p *Package) handleImplicitForwardDecl(name string) *gogen.TypeDecl {
 	// Using TypeDecl as the node kind here because forward declarations in C/C++ typically
 	// only occur with struct, class, and enum type declarations, not with typedefs or other declarations.
 	// The TypeDecl node kind ensures these forward declarations are properly tracked and later completed.
-	pubName, _, _, _ := p.RegisterNode(Node{name: name, kind: TypeDecl}, p.declName)
+	pubName, _, _, _ := p.RegisterNode(Node{name: name, kind: TypeDecl}, p.declName, p.lookupOrigin)
 	decl := p.emptyTypeDecl(pubName, nil)
 	inc := &Incomplete{
 		cname: name,
@@ -481,7 +495,7 @@ func (p *Package) NewTypedefDecl(typedefDecl *ast.TypedefDecl) error {
 	}
 
 	node := Node{name: typedefDecl.Name.Name, kind: TypedefDecl}
-	name, changed, exist, err := p.RegisterNode(node, p.declName)
+	name, changed, exist, err := p.RegisterNode(node, p.declName, p.lookupOrigin)
 	if err != nil {
 		return err
 	}
@@ -603,7 +617,7 @@ func (p *Package) createEnumType(enumName *ast.Ident) (types.Type, bool, error) 
 	var t *gogen.TypeDecl
 	if enumName != nil {
 		node := Node{name: enumName.Name, kind: EnumTypeDecl}
-		name, changed, exist, err = p.RegisterNode(node, p.declName)
+		name, changed, exist, err = p.RegisterNode(node, p.declName, p.lookupOrigin)
 		if err != nil {
 			return nil, false, errs.NewTypeDefinedError(name, enumName.Name)
 		}
@@ -626,7 +640,7 @@ func (p *Package) createEnumType(enumName *ast.Ident) (types.Type, bool, error) 
 func (p *Package) createEnumItems(items []*ast.EnumItem, enumType types.Type) error {
 	defs := p.NewConstGroup()
 	for _, item := range items {
-		name, changed, exist, err := p.RegisterNode(Node{name: item.Name.Name, kind: EnumItem}, p.declName)
+		name, _, exist, err := p.RegisterNode(Node{name: item.Name.Name, kind: EnumItem}, p.declName, p.lookupPub)
 		if err != nil {
 			return errs.NewTypeDefinedError(name, item.Name.Name)
 		}
@@ -641,11 +655,6 @@ func (p *Package) createEnumItems(items []*ast.EnumItem, enumType types.Type) er
 			log.Panicf("createEnumItems:fail to convert %T to int:%s", item.Value, err.Error())
 		}
 		defs.New(val, enumType, name)
-		if changed {
-			if obj := p.Lookup(name); obj != nil {
-				substObj(p.p.Types, p.p.Types.Scope(), item.Name.Name, obj)
-			}
-		}
 	}
 	return nil
 }
@@ -660,7 +669,7 @@ func (p *Package) NewMacro(macro *ast.Macro) error {
 		value := macro.Tokens[1].Lit
 		defs := p.NewConstGroup()
 		node := Node{name: macro.Name, kind: Macro}
-		name, _, exist, err := p.RegisterNode(node, p.macroName)
+		name, _, exist, err := p.RegisterNode(node, p.macroName, p.lookupPub)
 		if err != nil {
 			return err
 		}
@@ -819,13 +828,13 @@ func (p *Package) WritePubFile() error {
 
 type NameMethod func(name string) string
 
-func (p *Package) RegisterNode(node Node, nameMethod NameMethod) (pubName string, changed bool, exist bool, err error) {
+func (p *Package) RegisterNode(node Node, nameMethod NameMethod, lookup func(name string, pubName string) types.Object) (pubName string, changed bool, exist bool, err error) {
 	pubName, exist = p.symbols.Lookup(node)
 	if exist {
 		return pubName, pubName != node.name, exist, nil
 	}
 	pubName, changed = p.GetUniqueName(node, nameMethod)
-	obj := p.Lookup(node.name)
+	obj := lookup(node.name, pubName)
 	if obj != nil {
 		return "", false, exist, errs.NewTypeDefinedError(pubName, node.name)
 	}

--- a/cmd/gogensig/convert/package.go
+++ b/cmd/gogensig/convert/package.go
@@ -365,7 +365,7 @@ func (p *Package) lookupOrigin(name string, pubName string) types.Object {
 	return nil
 }
 
-func (p *Package) lookupPub(name string, pubName string) types.Object {
+func (p *Package) lookupPub(_ string, pubName string) types.Object {
 	return p.Lookup(pubName)
 }
 

--- a/cmd/gogensig/convert/package_test.go
+++ b/cmd/gogensig/convert/package_test.go
@@ -1270,6 +1270,18 @@ func TestRedef(t *testing.T) {
 		t.Fatal("expect a redefine err")
 	}
 
+	err = pkg.NewTypeDecl(&ast.TypeDecl{
+		Name: &ast.Ident{Name: "Bar"},
+		Type: &ast.RecordType{
+			Tag:    ast.Struct,
+			Fields: flds,
+		},
+	})
+
+	if err == nil {
+		t.Fatal("expect a redefine err")
+	}
+
 	err = pkg.NewFuncDecl(&ast.FuncDecl{
 		Name:        &ast.Ident{Name: "Bar"},
 		MangledName: "Bar",
@@ -1353,6 +1365,8 @@ func TestRedefEnum(t *testing.T) {
 			Type: &ast.EnumType{
 				Items: []*ast.EnumItem{
 					{Name: &ast.Ident{Name: "Foo"}, Value: &ast.BasicLit{Kind: ast.IntLit, Value: "0"}},
+					// check if skip same name
+					{Name: &ast.Ident{Name: "Foo"}, Value: &ast.BasicLit{Kind: ast.IntLit, Value: "0"}},
 				},
 			},
 		})
@@ -1371,6 +1385,7 @@ type Foo struct {
 const Foo__1 c.Int = 0
 `)
 	})
+
 }
 
 func TestRedefineFunc(t *testing.T) {

--- a/cmd/gogensig/convert/package_test.go
+++ b/cmd/gogensig/convert/package_test.go
@@ -1279,42 +1279,6 @@ func TestRedef(t *testing.T) {
 		t.Fatal("unexpect redefine err")
 	}
 
-	err = pkg.NewEnumTypeDecl(&ast.EnumTypeDecl{
-		Name: &ast.Ident{Name: "Foo"},
-		Type: &ast.EnumType{},
-	})
-
-	if err == nil {
-		t.Fatal("Expect a redefine err")
-	}
-
-	err = pkg.NewEnumTypeDecl(&ast.EnumTypeDecl{
-		Name: nil,
-		Type: &ast.EnumType{
-			Items: []*ast.EnumItem{
-				{Name: &ast.Ident{Name: "Foo"}, Value: &ast.BasicLit{Kind: ast.IntLit, Value: "0"}},
-			},
-		},
-	})
-
-	if err == nil {
-		t.Fatal("Expect a redefine err")
-	}
-
-	err = pkg.NewEnumTypeDecl(&ast.EnumTypeDecl{
-		Name: &ast.Ident{Name: "EnumFoo"},
-		Type: &ast.EnumType{
-			Items: []*ast.EnumItem{
-				{Name: &ast.Ident{Name: "ItemBar"}, Value: &ast.BasicLit{Kind: ast.IntLit, Value: "0"}},
-				{Name: &ast.Ident{Name: "ItemBar"}, Value: &ast.BasicLit{Kind: ast.IntLit, Value: "1"}},
-			},
-		},
-	})
-
-	if err != nil {
-		t.Fatal("unexpect err")
-	}
-
 	macro := &ast.Macro{
 		Loc:    &ast.Location{File: tempFile.File},
 		Name:   "MACRO_FOO",
@@ -1350,12 +1314,63 @@ type Foo struct {
 //go:linkname Bar C.Bar
 func Bar()
 
-type EnumFoo c.Int
-
-const ItemBar EnumFoo = 0
 const MACRO_FOO = 1
 `
 	comparePackageOutput(t, pkg, expect)
+}
+
+func TestRedefEnum(t *testing.T) {
+	typDecl := &ast.TypeDecl{
+		Name: &ast.Ident{Name: "Foo"},
+		Type: &ast.RecordType{
+			Tag: ast.Struct,
+			Fields: &ast.FieldList{
+				List: []*ast.Field{
+					{Type: &ast.BuiltinType{Kind: ast.Int}},
+				},
+			},
+		},
+	}
+	t.Run("redefine enum type", func(t *testing.T) {
+		pkg := createTestPkg(t, &convert.PackageConfig{})
+		pkg.SetCurFile(tempFile)
+		pkg.NewTypeDecl(typDecl)
+		err := pkg.NewEnumTypeDecl(&ast.EnumTypeDecl{
+			Name: &ast.Ident{Name: "Foo"},
+			Type: &ast.EnumType{},
+		})
+		if err == nil {
+			t.Fatal("expect a redefine err")
+		}
+	})
+
+	t.Run("redefine enum item", func(t *testing.T) {
+		pkg := createTestPkg(t, &convert.PackageConfig{})
+		pkg.SetCurFile(tempFile)
+		pkg.NewTypeDecl(typDecl)
+		pkg.NewEnumTypeDecl(&ast.EnumTypeDecl{
+			Name: nil,
+			Type: &ast.EnumType{
+				Items: []*ast.EnumItem{
+					{Name: &ast.Ident{Name: "Foo"}, Value: &ast.BasicLit{Kind: ast.IntLit, Value: "0"}},
+				},
+			},
+		})
+		comparePackageOutput(t, pkg, `
+package testpkg
+
+import (
+	"github.com/goplus/lib/c"
+	_ "unsafe"
+)
+
+type Foo struct {
+	 c.Int
+}
+
+const Foo__1 c.Int = 0
+`)
+	})
 }
 
 func TestRedefineFunc(t *testing.T) {


### PR DESCRIPTION
follow is valid,but current panic.
```
struct isl_arg_choice {
    const char *name;
    unsigned value;
};
enum isl_arg_type {
    // ....
    isl_arg_choice
    // ....
};
```
The isl_arg_choice as an enum item is still checked for whether its cname is in the current scope, used to submit a cname -> pubnamed type. However, for enum values, they exist as constant values and are not referenced as types in the code (e.g., syntax like isl_arg_choice x is invalid). Therefore, during the conversion process, we do not need to check the origin name of macros and enum items, but only verify their converted pubname.