### PR TITLE
llcppg:unify read cfg method

### DIFF
--- a/_xtool/llcppsigfetch/llcppsigfetch.go
+++ b/_xtool/llcppsigfetch/llcppsigfetch.go
@@ -91,8 +91,7 @@ func main() {
 	} else {
 		conf, err := config.GetConf(ags.UseStdin, ags.CfgFile)
 		check(err)
-		defer conf.Delete()
-		parseConfig.Conf = conf.Config
+		parseConfig.Conf = conf
 	}
 
 	err := parse.Do(parseConfig)

--- a/_xtool/llcppsymg/llcppsymg.go
+++ b/_xtool/llcppsymg/llcppsymg.go
@@ -36,7 +36,6 @@ func main() {
 
 	conf, err := config.GetConf(ags.UseStdin, ags.CfgFile)
 	check(err)
-	defer conf.Delete()
 
 	if ags.VerboseParseIsMethod {
 		symg.SetDebug(symg.DbgParseIsMethod)
@@ -63,7 +62,7 @@ func main() {
 	}
 
 	err = symg.Do(&symg.Config{
-		Conf: conf.Config,
+		Conf: conf,
 	})
 	check(err)
 }

--- a/_xtool/llcppsymg/tool/config/cfgparse/parse.go
+++ b/_xtool/llcppsymg/tool/config/cfgparse/parse.go
@@ -1,11 +1,15 @@
 package cfgparse
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/goplus/llcppg/config"
 )
 
 // Note: This package is not placed under the 'config' package because 'config'
@@ -108,4 +112,22 @@ func (cf *CFlags) GenHeaderFilePaths(files []string, defaultPaths []string) ([]s
 	}
 
 	return foundPaths, notFound, nil
+}
+
+func NewConfigFromByte(data []byte) (*config.Config, error) {
+	conf := config.NewDefault()
+	err := json.Unmarshal(data, &conf)
+	if err != nil {
+		return nil, err
+	}
+	return conf, nil
+}
+
+func ReadFile(filePath string) ([]byte, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return io.ReadAll(file)
 }

--- a/_xtool/llcppsymg/tool/config/config.go
+++ b/_xtool/llcppsymg/tool/config/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/goplus/lib/c"
 	"github.com/goplus/lib/c/clang"
 	clangutils "github.com/goplus/llcppg/_xtool/llcppsymg/tool/clang"
+	"github.com/goplus/llcppg/_xtool/llcppsymg/tool/config/cfgparse"
 	llcppg "github.com/goplus/llcppg/config"
 	llgoc "github.com/goplus/llgo/c"
 	"github.com/goplus/llpkg/cjson"
@@ -21,7 +22,7 @@ type Conf struct {
 	*llcppg.Config
 }
 
-func GetConf(useStdin bool, cfgFile string) (conf Conf, err error) {
+func GetConf(useStdin bool, cfgFile string) (conf *llcppg.Config, err error) {
 	var data []byte
 	if useStdin {
 		data, err = io.ReadAll(os.Stdin)
@@ -31,7 +32,7 @@ func GetConf(useStdin bool, cfgFile string) (conf Conf, err error) {
 	if err != nil {
 		return
 	}
-	conf, err = GetConfByByte(data)
+	conf, err = cfgparse.NewConfigFromByte(data)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
now,llgo support json.Unmarshal,so we can unify the usage of read llcppg.cfg

--- 
got some panic,mini reproduce
```go
package main

import (
	"encoding/json"
	"fmt"
)

type ImplFiles struct {
	Files []string `json:"files"`
}

type Config struct {
	Impl []ImplFiles `json:"impl"`
}

func main() {
	content :=
		`
{
  "impl": [
    {
      "files": []
    }
  ]
}
`

	var cfg Config
	err := json.Unmarshal([]byte(content), &cfg)
	if err != nil {
		fmt.Println("error:", err)
	}
	fmt.Println(cfg)
}
```
got
```
_xtool/llcppsigfetch/test on  fetch/info [$!?] via 🐹 v1.23.4 took 4s 
❯ go run .         
{[{[]}]}
(base) 
_xtool/llcppsigfetch/test on  fetch/info [$!?] via 🐹 v1.23.4 
❯ llgo run .
panic: runtime error: invalid memory address or nil pointer dereference

[0x00AE432C github.com/goplus/llgo/runtime/internal/runtime.Rethrow+0x37, SP = 0x6c]
[0x00AE3F54 github.com/goplus/llgo/runtime/internal/runtime.Panic+0x35, SP = 0x50]
[0x00AE9B80 github.com/goplus/llgo/runtime/internal/runtime.init#4$1+0x38, SP = 0x5c]
[0x97576584 _sigtramp+0x9, SP = 0x38]
[0x00996078 sync.(*entry).load+0x12, SP = 0xc]
(base) 
```