### PR TITLE
cl/fix:test deps internal/convert's pkg

### DIFF
--- a/cl/internal/convert/_testdata/_depcjson/conf/llcppg.cfg
+++ b/cl/internal/convert/_testdata/_depcjson/conf/llcppg.cfg
@@ -5,9 +5,9 @@
   "libs": "$(pkg-config --libs libcjson)",
   "cplusplus":false,
   "deps": [
-    "github.com/goplus/llcppg/cmd/gogensig/convert/testdata/cjson",
-    "github.com/goplus/llcppg/cmd/gogensig/convert/testdata/thirddep",
-    "github.com/goplus/llcppg/cmd/gogensig/convert/testdata/thirddep2",
-    "github.com/goplus/llcppg/cmd/gogensig/convert/testdata/thirddep3"
+    "github.com/goplus/llcppg/cl/internal/convert/testdata/cjson",
+    "github.com/goplus/llcppg/cl/internal/convert/testdata/thirddep",
+    "github.com/goplus/llcppg/cl/internal/convert/testdata/thirddep2",
+    "github.com/goplus/llcppg/cl/internal/convert/testdata/thirddep3"
   ]
 }

--- a/cl/internal/convert/_testdata/_depcjson/gogensig.expect
+++ b/cl/internal/convert/_testdata/_depcjson/gogensig.expect
@@ -13,10 +13,10 @@ package depcjson
 
 import (
 	_ "github.com/goplus/lib/c"
-	_ "github.com/goplus/llcppg/cmd/gogensig/convert/testdata/cjson"
-	_ "github.com/goplus/llcppg/cmd/gogensig/convert/testdata/thirddep"
-	_ "github.com/goplus/llcppg/cmd/gogensig/convert/testdata/thirddep2"
-	_ "github.com/goplus/llcppg/cmd/gogensig/convert/testdata/thirddep3"
+	_ "github.com/goplus/llcppg/cl/internal/convert/testdata/cjson"
+	_ "github.com/goplus/llcppg/cl/internal/convert/testdata/thirddep"
+	_ "github.com/goplus/llcppg/cl/internal/convert/testdata/thirddep2"
+	_ "github.com/goplus/llcppg/cl/internal/convert/testdata/thirddep3"
 )
 
 const LLGoPackage string = "link: $(pkg-config --libs libcjson);"
@@ -26,11 +26,11 @@ package depcjson
 
 import (
 	"github.com/goplus/lib/c"
-	"github.com/goplus/llcppg/cmd/gogensig/convert/testdata/basicdep"
-	"github.com/goplus/llcppg/cmd/gogensig/convert/testdata/cjson"
-	"github.com/goplus/llcppg/cmd/gogensig/convert/testdata/thirddep"
-	"github.com/goplus/llcppg/cmd/gogensig/convert/testdata/thirddep2"
-	"github.com/goplus/llcppg/cmd/gogensig/convert/testdata/thirddep3"
+	"github.com/goplus/llcppg/cl/internal/convert/testdata/basicdep"
+	"github.com/goplus/llcppg/cl/internal/convert/testdata/cjson"
+	"github.com/goplus/llcppg/cl/internal/convert/testdata/thirddep"
+	"github.com/goplus/llcppg/cl/internal/convert/testdata/thirddep2"
+	"github.com/goplus/llcppg/cl/internal/convert/testdata/thirddep3"
 	_ "unsafe"
 )
 

--- a/cl/internal/convert/convert_test.go
+++ b/cl/internal/convert/convert_test.go
@@ -349,15 +349,22 @@ func prepareEnv(name string, deps []string) (string, error) {
 		return "", err
 	}
 
-	err = convert.ModInit(deps, outputDir, name)
+	// with the same module to import the internal/testdata/pkg
+	err = config.RunCommand(outputDir, "go", "mod", "init", "github.com/goplus/llcppg/cl/internal/"+name)
 	if err != nil {
 		return "", err
 	}
+
 	err = config.RunCommand(outputDir, "go", "get", "github.com/goplus/llcppg")
 	if err != nil {
 		return "", err
 	}
 	err = config.RunCommand(outputDir, "go", "mod", "edit", "-replace", "github.com/goplus/llcppg="+projectRoot)
+	if err != nil {
+		return "", err
+	}
+
+	err = convert.ModInit(deps, outputDir, "")
 	if err != nil {
 		return "", err
 	}

--- a/cl/internal/convert/package_test.go
+++ b/cl/internal/convert/package_test.go
@@ -2101,8 +2101,8 @@ func TestImport(t *testing.T) {
 		}
 		p.PkgInfo = convert.NewPkgInfo(".", ".", &llcppg.Config{
 			Deps: []string{
-				"github.com/goplus/llcppg/cmd/gogensig/convert/testdata/invalidpath",
-				"github.com/goplus/llcppg/cmd/gogensig/convert/testdata/partfinddep",
+				"github.com/goplus/llcppg/cl/internal/convert/testdata/invalidpath",
+				"github.com/goplus/llcppg/cl/internal/convert/testdata/partfinddep",
 			},
 		}, nil)
 		loader := convert.NewPkgDepLoader(mod, genPkg)
@@ -2122,7 +2122,7 @@ func TestImport(t *testing.T) {
 			PkgBase: convert.PkgBase{
 				CppgConf: &llcppg.Config{
 					Deps: []string{
-						"github.com/goplus/llcppg/cmd/gogensig/convert/testdata/invalidpub",
+						"github.com/goplus/llcppg/cl/internal/convert/testdata/invalidpub",
 					},
 				},
 			},
@@ -2137,7 +2137,7 @@ func TestImport(t *testing.T) {
 			PkgBase: convert.PkgBase{
 				CppgConf: &llcppg.Config{
 					Deps: []string{
-						"github.com/goplus/llcppg/cmd/gogensig/convert/testdata/invaliddep",
+						"github.com/goplus/llcppg/cl/internal/convert/testdata/invaliddep",
 					},
 				},
 			},
@@ -2152,8 +2152,8 @@ func TestImport(t *testing.T) {
 			PkgBase: convert.PkgBase{
 				CppgConf: &llcppg.Config{
 					Deps: []string{
-						"github.com/goplus/llcppg/cmd/gogensig/convert/testdata/cjson",
-						"github.com/goplus/llcppg/cmd/gogensig/convert/testdata/cjsonbool",
+						"github.com/goplus/llcppg/cl/internal/convert/testdata/cjson",
+						"github.com/goplus/llcppg/cl/internal/convert/testdata/cjsonbool",
 					},
 				},
 			},

--- a/cl/internal/convert/testdata/invaliddep/llcppg.cfg
+++ b/cl/internal/convert/testdata/invaliddep/llcppg.cfg
@@ -1,5 +1,5 @@
 {
   "name": "invaliddep",
   "cplusplus":false,
-  "deps":["github.com/goplus/llcppg/cmd/gogensig/convert/testdata/invalidcfg"]
+  "deps":["github.com/goplus/llcppg/cl/internal/convert/testdata/invalidcfg"]
 }

--- a/cl/internal/convert/testdata/thirddep/llcppg.cfg
+++ b/cl/internal/convert/testdata/thirddep/llcppg.cfg
@@ -4,6 +4,6 @@
     "type.h",
     "thirddep.h"
   ],
-  "deps":["github.com/goplus/llcppg/cmd/gogensig/convert/testdata/basicdep"],
+  "deps":["github.com/goplus/llcppg/cl/internal/convert/testdata/basicdep"],
   "cplusplus": false
 }

--- a/cl/internal/convert/testdata/thirddep2/llcppg.cfg
+++ b/cl/internal/convert/testdata/thirddep2/llcppg.cfg
@@ -4,6 +4,6 @@
     "type.h",
     "thirddep2.h"
   ],
-  "deps":["github.com/goplus/llcppg/cmd/gogensig/convert/testdata/thirddep","github.com/goplus/llcppg/cmd/gogensig/convert/testdata/basicdep"],
+  "deps":["github.com/goplus/llcppg/cl/internal/convert/testdata/thirddep","github.com/goplus/llcppg/cl/internal/convert/testdata/basicdep"],
   "cplusplus": false
 }

--- a/cl/internal/convert/testdata/thirddep2/thirddep2.go
+++ b/cl/internal/convert/testdata/thirddep2/thirddep2.go
@@ -3,8 +3,8 @@ package thirddep2
 import (
 	_ "unsafe"
 
-	"github.com/goplus/llcppg/cmd/gogensig/convert/testdata/basicdep"
-	"github.com/goplus/llcppg/cmd/gogensig/convert/testdata/thirddep"
+	"github.com/goplus/llcppg/cl/internal/convert/testdata/basicdep"
+	"github.com/goplus/llcppg/cl/internal/convert/testdata/thirddep"
 )
 
 type ThirdDep2 struct {


### PR DESCRIPTION
```
go: module github.com/goplus/llcppg@upgrade found (v0.3.1), but does not contain package github.com/goplus/llcppg/cl/internal/convert/testdata/cjson
```