### PR TITLE
cl/convert:NodeConvert

### DIFF
--- a/cl/convert.go
+++ b/cl/convert.go
@@ -6,6 +6,8 @@ import (
 	llconfig "github.com/goplus/llcppg/config"
 )
 
+var ErrSkip = convert.ErrSkip
+
 const DbgFlagAll = convert.DbgFlagAll
 
 func SetDebug(flag int) {
@@ -16,6 +18,8 @@ func ModInit(deps []string, outputDir string, modulePath string) error {
 	return convert.ModInit(deps, outputDir, modulePath)
 }
 
+type NodeConverter = convert.NodeConverter
+
 type ConvConfig struct {
 	OutputDir string
 	PkgPath   string
@@ -23,6 +27,7 @@ type ConvConfig struct {
 	Pkg       *ast.File
 	FileMap   map[string]*llconfig.FileInfo
 	ConvSym   func(name *ast.Object, mangleName string) (goName string, err error)
+	NodeConv  NodeConverter
 
 	// CfgFile   string // llcppg.cfg
 	TypeMap        map[string]string // llcppg.pub
@@ -34,13 +39,13 @@ type ConvConfig struct {
 
 func Convert(config *ConvConfig) (pkg Package, err error) {
 	cvt, err := convert.NewConverter(&convert.Config{
-		OutputDir: config.OutputDir,
-		PkgPath:   config.PkgPath,
-		PkgName:   config.PkgName,
-		Pkg:       config.Pkg,
-		FileMap:   config.FileMap,
-		ConvSym:   config.ConvSym,
-
+		OutputDir:      config.OutputDir,
+		PkgPath:        config.PkgPath,
+		PkgName:        config.PkgName,
+		Pkg:            config.Pkg,
+		FileMap:        config.FileMap,
+		ConvSym:        config.ConvSym,
+		NodeConv:       config.NodeConv,
 		TypeMap:        config.TypeMap,
 		Deps:           config.Deps,
 		TrimPrefixes:   config.TrimPrefixes,

--- a/cl/internal/convert/convert.go
+++ b/cl/internal/convert/convert.go
@@ -1,6 +1,7 @@
 package convert
 
 import (
+	"errors"
 	"log"
 	"strings"
 
@@ -8,6 +9,16 @@ import (
 	cfg "github.com/goplus/llcppg/cmd/gogensig/config"
 	llconfig "github.com/goplus/llcppg/config"
 )
+
+var (
+	ErrSkip = errors.New("skip this node")
+)
+
+type NodeConverter interface {
+	ConvDecl(decl ast.Decl) (goName, goFile string, err error) // ErrSkip
+	ConvEnumItem(decl *ast.EnumTypeDecl, item *ast.EnumItem) (goName, goFile string, err error)
+	ConvMacro(macro *ast.Macro) (goName, goFile string, err error)
+}
 
 type dbgFlags = int
 
@@ -29,7 +40,7 @@ type Config struct {
 	Pkg       *ast.File
 	FileMap   map[string]*llconfig.FileInfo
 	ConvSym   func(name *ast.Object, mangleName string) (goName string, err error)
-
+	NodeConv  NodeConverter
 	// CfgFile   string // llcppg.cfg
 	TypeMap        map[string]string // llcppg.pub
 	Deps           []string          // dependent packages

--- a/cmd/gogensig/gogensig_test.go
+++ b/cmd/gogensig/gogensig_test.go
@@ -15,7 +15,11 @@ import (
 )
 
 func TestMain(t *testing.T) {
-	testFromDir(t, "testdata", false)
+	testFromDir(t, "testdata", true)
+}
+
+func TestLua(t *testing.T) {
+	testFrom(t, "/Users/zhangzhiyang/Documents/Code/goplus/llcppg/cmd/gogensig/testdata/lua", "lua", true)
 }
 
 func testFromDir(t *testing.T, relDir string, gen bool) {


### PR DESCRIPTION
cl中通过NodeConverter来决定某个符号输出到某个go文件、类型名、是否当前Package。
```go
type NodeConverter interface {
	ConvDecl(decl ast.Decl) (goName, goFile string, err error) // ErrSkip
	ConvEnumItem(decl *ast.EnumTypeDecl, item *ast.EnumItem) (goName string, err error)
	ConvMacro(macro *ast.Macro) (goName, goFile string, err error)
}
```

- [ ] 去除FileMap在`package`中的耦合