### PR TITLE
cl/nc:only record third type which have name

### DIFF
--- a/cl/nc/ncimpl/ncimpl.go
+++ b/cl/nc/ncimpl/ncimpl.go
@@ -55,7 +55,7 @@ func (p *Converter) convFile(file string, obj *ast.Object) (goFile string, ok bo
 			file, strings.Join(availableFiles, "\n"))
 	}
 	hf := NewHeaderFile(file, info.FileType)
-	if obj != nil && hf.FileType == llconfig.Third {
+	if obj != nil && obj.Name != nil && hf.FileType == llconfig.Third {
 		p.locMap.Add(obj.Name, obj.Loc)
 	}
 	return hf.ToGoFileName(p.PkgName), hf.InCurPkg()


### PR DESCRIPTION
avoid collect anony enumtype to `locMap`
```json
{
  "_Type":	"EnumTypeDecl",
  "Loc":	{
	  "_Type":	"Location",
	  "File":	"/usr/include/aarch64-linux-gnu/bits/confname.h"
  },
  "Doc":	null,
  "Parent":	null,
  "Name":	null,
  "Type":	{"..."}
}
```