### PR TITLE
ci:check llgo test's stderr to exit

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,16 @@ jobs:
         # llgo test ./_xtool/internal/parser/...
         # got go/bin/parser.test: exit code -1
         cd _xtool/internal/parser
-        llgo test ./...
+        # check exit code outout for temporary fix
+        # with the latest update can exit in llgo test
+        # only with llgo test ./... with llgo update
+        # https://github.com/goplus/llgo/pull/1128
+        output=$(llgo test ./... 2>&1)
+        echo "$output"
+        if echo "$output" | grep -q "exit code [^0]"; then
+          echo "llgo test fail"
+          exit 1
+        fi
 
     - name: Test llcppsymg & llcppsigfetch
       run: |

--- a/_xtool/internal/parser/parser_test.go
+++ b/_xtool/internal/parser/parser_test.go
@@ -397,7 +397,7 @@ func TestBuiltinType(t *testing.T) {
 		typ      clang.Type
 		expected ast.BuiltinType
 	}{
-		{"Void", btType(clang.TypeVoid), ast.BuiltinType{Kind: ast.Void}},
+		{"Void", btType(clang.TypeVoid), ast.BuiltinType{Kind: ast.Bool}},
 		{"Bool", btType(clang.TypeBool), ast.BuiltinType{Kind: ast.Bool}},
 		{"Char_S", btType(clang.TypeCharS), ast.BuiltinType{Kind: ast.Char, Flags: ast.Signed}},
 		{"Char_U", btType(clang.TypeCharU), ast.BuiltinType{Kind: ast.Char, Flags: ast.Unsigned}},

--- a/_xtool/internal/parser/parser_test.go
+++ b/_xtool/internal/parser/parser_test.go
@@ -397,7 +397,7 @@ func TestBuiltinType(t *testing.T) {
 		typ      clang.Type
 		expected ast.BuiltinType
 	}{
-		{"Void", btType(clang.TypeVoid), ast.BuiltinType{Kind: ast.Bool}},
+		{"Void", btType(clang.TypeVoid), ast.BuiltinType{Kind: ast.Void}},
 		{"Bool", btType(clang.TypeBool), ast.BuiltinType{Kind: ast.Bool}},
 		{"Char_S", btType(clang.TypeCharS), ast.BuiltinType{Kind: ast.Char, Flags: ast.Signed}},
 		{"Char_U", btType(clang.TypeCharU), ast.BuiltinType{Kind: ast.Char, Flags: ast.Unsigned}},


### PR DESCRIPTION
can exit expect when llgo test

https://github.com/goplus/llcppg/actions/runs/15177637874/job/42680771642?pr=364
https://github.com/goplus/llcppg/actions/runs/15177637874/job/42680866353?pr=364
```bash
Run # llgo test ./_xtool/internal/parser/...
todo: unknown builtin type: Ibm128
--- FAIL: TestBuiltinType (0.02s)
    ???:1: Void Kind mismatch:got 0 want 1, 
FAIL
/home/runner/go/bin/parser.test: exit code 1
llgo test fail
Error: Process completed with exit code 1.
```