### PR TITLE
test(e2etest):log2file & test parallel

### DIFF
--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -40,7 +40,19 @@ jobs:
     - name: Set up Conan
       run: conan profile detect
     
+    - name: Setup Log directory
+      run: echo "LLCPPG_TEST_LOG_DIR=$(mktemp -d)" >> $GITHUB_ENV
+
     - name: Test End2End
       working-directory: _cmptest
       run: |
         go test -v .
+
+    - name: Upload Logs to Artifacts
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: ${{matrix.os}}-log
+        path: ${{env.LLCPPG_TEST_LOG_DIR}}
+        retention-days: 1
+        include-hidden-files: true

--- a/_cmptest/llcppgend_test.go
+++ b/_cmptest/llcppgend_test.go
@@ -111,8 +111,9 @@ func testFrom(t *testing.T, tc testCase, gen bool) {
 
 	os.WriteFile(filepath.Join(resultDir, config.LLCPPG_CFG), cfg, os.ModePerm)
 
-	installer := conan.NewConanInstaller(tc.config)
-	err = conanInstall(t, installer, tc.pkg, conanDir)
+	conanInstallMutex.Lock()
+	_, err = conan.NewConanInstaller(tc.config).Install(tc.pkg, conanDir)
+	conanInstallMutex.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,13 +194,6 @@ func runDemos(t *testing.T, logFile *os.File, demosPath string, pkgname, pkgpath
 		}
 	}
 
-}
-
-func conanInstall(t *testing.T, installer upstream.Installer, pkg upstream.Package, conanDir string) error {
-	conanInstallMutex.Lock()
-	defer conanInstallMutex.Unlock()
-	_, err := installer.Install(pkg, conanDir)
-	return err
 }
 
 func appendPCPath(path string) string {

--- a/_cmptest/llcppgend_test.go
+++ b/_cmptest/llcppgend_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/goplus/llcppg/config"
@@ -43,6 +45,29 @@ var testCases = []testCase{
 	},
 }
 
+var mkdirTempLazily = sync.OnceValue(func() string {
+	if env := os.Getenv("LLCPPG_TEST_LOG_DIR"); env != "" {
+		return env
+	}
+	dir, err := os.MkdirTemp("", "test-log")
+	if err != nil {
+		panic(err)
+	}
+	return dir
+})
+
+func logFile(tc testCase) (*os.File, error) {
+	dirName := fmt.Sprintf("%s-%s-llcppg-%s-%s", runtime.GOOS, runtime.GOARCH, tc.pkg.Name, tc.pkg.Version)
+	dirPath := filepath.Join(mkdirTempLazily(), dirName)
+
+	err := os.MkdirAll(dirPath, 0755)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.Create(filepath.Join(dirPath, "all.log"))
+}
+
 func TestEnd2End(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
@@ -53,6 +78,13 @@ func TestEnd2End(t *testing.T) {
 }
 
 func testFrom(t *testing.T, tc testCase, gen bool) {
+	logFile, err := logFile(tc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logFile.Close()
+	fmt.Printf("%s:%s log file: %s\n", tc.pkg.Name, tc.pkg.Version, logFile.Name())
+
 	wd, _ := os.Getwd()
 	dir := filepath.Join(wd, tc.dir)
 	conanDir, err := os.MkdirTemp("", "llcppg_end2end_test_conan_dir_*")
@@ -79,7 +111,7 @@ func testFrom(t *testing.T, tc testCase, gen bool) {
 		t.Fatal(err)
 	}
 
-	cmd := command(resultDir, "llcppg", "-v", "-mod="+tc.modpath)
+	cmd := command(logFile, resultDir, "llcppg", "-v", "-mod="+tc.modpath)
 	cmd.Env = append(cmd.Env, goVerEnv())
 	cmd.Env = append(cmd.Env, pcPathEnv(conanDir)...)
 
@@ -97,17 +129,17 @@ func testFrom(t *testing.T, tc testCase, gen bool) {
 	} else {
 		// check the result is the same as the expected result
 		// when have diff,will got exit code 1
-		diffCmd := command(wd, "git", "diff", "--no-index", dir, resultDir)
+		diffCmd := command(logFile, wd, "git", "diff", "--no-index", dir, resultDir)
 		err = diffCmd.Run()
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
-	runDemos(t, filepath.Join(wd, tc.demosDir), tc.pkg.Name, filepath.Join(dir, tc.pkg.Name), conanDir)
+	runDemos(t, logFile, filepath.Join(wd, tc.demosDir), tc.pkg.Name, filepath.Join(dir, tc.pkg.Name), conanDir)
 }
 
 // pkgpath is the filepath use to replace the import path in demo's go.mod
-func runDemos(t *testing.T, demosPath string, pkgname, pkgpath, pcPath string) {
+func runDemos(t *testing.T, logFile *os.File, demosPath string, pkgname, pkgpath, pcPath string) {
 	tempDemosPath, err := os.MkdirTemp("", "llcppg_end2end_test_demos_*")
 	if err != nil {
 		t.Fatal(err)
@@ -118,19 +150,19 @@ func runDemos(t *testing.T, demosPath string, pkgname, pkgpath, pcPath string) {
 		t.Fatal(err)
 	}
 
-	goMod := command(tempDemosPath, "go", "mod", "init", "test")
+	goMod := command(logFile, tempDemosPath, "go", "mod", "init", "test")
 	err = goMod.Run()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	replace := command(tempDemosPath, "go", "mod", "edit", "-replace", pkgname+"="+pkgpath)
+	replace := command(logFile, tempDemosPath, "go", "mod", "edit", "-replace", pkgname+"="+pkgpath)
 	err = replace.Run()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	tidy := command(tempDemosPath, "go", "mod", "tidy")
+	tidy := command(logFile, tempDemosPath, "go", "mod", "tidy")
 	err = tidy.Run()
 	if err != nil {
 		t.Fatal(err)
@@ -146,7 +178,7 @@ func runDemos(t *testing.T, demosPath string, pkgname, pkgpath, pcPath string) {
 			continue
 		}
 		demoPath := filepath.Join(tempDemosPath, demo.Name())
-		demoCmd := command(demoPath, "llgo", "run", ".")
+		demoCmd := command(logFile, demoPath, "llgo", "run", ".")
 		demoCmd.Env = append(demoCmd.Env, llgoEnv()...)
 		demoCmd.Env = append(demoCmd.Env, pcPathEnv(pcPath)...)
 		err = demoCmd.Run()
@@ -183,10 +215,10 @@ func goVerEnv() string {
 	return fmt.Sprintf("GOTOOLCHAIN=go%s", llcppgGoVersion)
 }
 
-func command(dir string, app string, args ...string) *exec.Cmd {
+func command(logFile *os.File, dir string, app string, args ...string) *exec.Cmd {
 	cmd := exec.Command(app, args...)
 	cmd.Dir = dir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
 	return cmd
 }

--- a/_cmptest/llcppgend_test.go
+++ b/_cmptest/llcppgend_test.go
@@ -16,6 +16,9 @@ import (
 
 const llcppgGoVersion = "1.20.14"
 
+// avoid conan install race condition
+var conanInstallMutex sync.Mutex
+
 type testCase struct {
 	modpath  string
 	dir      string
@@ -107,7 +110,9 @@ func testFrom(t *testing.T, tc testCase, gen bool) {
 	}
 
 	os.WriteFile(filepath.Join(resultDir, config.LLCPPG_CFG), cfg, os.ModePerm)
-	_, err = conan.NewConanInstaller(tc.config).Install(tc.pkg, conanDir)
+
+	installer := conan.NewConanInstaller(tc.config)
+	err = conanInstall(t, installer, tc.pkg, conanDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,6 +193,13 @@ func runDemos(t *testing.T, logFile *os.File, demosPath string, pkgname, pkgpath
 		}
 	}
 
+}
+
+func conanInstall(t *testing.T, installer upstream.Installer, pkg upstream.Package, conanDir string) error {
+	conanInstallMutex.Lock()
+	defer conanInstallMutex.Unlock()
+	_, err := installer.Install(pkg, conanDir)
+	return err
 }
 
 func appendPCPath(path string) string {

--- a/_cmptest/llcppgend_test.go
+++ b/_cmptest/llcppgend_test.go
@@ -60,15 +60,15 @@ var mkdirTempLazily = sync.OnceValue(func() string {
 })
 
 func logFile(tc testCase) (*os.File, error) {
-	dirName := fmt.Sprintf("%s-%s-llcppg-%s-%s", runtime.GOOS, runtime.GOARCH, tc.pkg.Name, tc.pkg.Version)
-	dirPath := filepath.Join(mkdirTempLazily(), dirName)
+	caseName := fmt.Sprintf("%s-%s-llcppg-%s-%s", runtime.GOOS, runtime.GOARCH, tc.pkg.Name, tc.pkg.Version)
+	dirPath := filepath.Join(mkdirTempLazily(), caseName)
 
 	err := os.MkdirAll(dirPath, 0755)
 	if err != nil {
 		return nil, err
 	}
 
-	return os.Create(filepath.Join(dirPath, "all.log"))
+	return os.Create(filepath.Join(dirPath, fmt.Sprintf("%s.log", caseName)))
 }
 
 func TestEnd2End(t *testing.T) {

--- a/_cmptest/llcppgend_test.go
+++ b/_cmptest/llcppgend_test.go
@@ -72,6 +72,7 @@ func TestEnd2End(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(fmt.Sprintf("%s/%s", tc.pkg.Name, tc.pkg.Version), func(t *testing.T) {
+			t.Parallel()
 			testFrom(t, tc, false)
 		})
 	}

--- a/cmd/gogensig/gogensig.go
+++ b/cmd/gogensig/gogensig.go
@@ -107,11 +107,11 @@ func main() {
 	err = writePkg(pkg.Package, outputDir)
 	check(err)
 
-	err = runCommand(outputDir, "go", "fmt", ".")
-	check(err)
+	// err = runCommand(outputDir, "go", "fmt", ".")
+	// check(err)
 
-	err = runCommand(outputDir, "go", "mod", "tidy")
-	check(err)
+	// err = runCommand(outputDir, "go", "mod", "tidy")
+	// check(err)
 }
 
 // Write all files in the package to the output directory

--- a/cmd/gogensig/gogensig.go
+++ b/cmd/gogensig/gogensig.go
@@ -107,11 +107,11 @@ func main() {
 	err = writePkg(pkg.Package, outputDir)
 	check(err)
 
-	// err = runCommand(outputDir, "go", "fmt", ".")
-	// check(err)
+	err = runCommand(outputDir, "go", "fmt", ".")
+	check(err)
 
-	// err = runCommand(outputDir, "go", "mod", "tidy")
-	// check(err)
+	err = runCommand(outputDir, "go", "mod", "tidy")
+	check(err)
 }
 
 // Write all files in the package to the output directory


### PR DESCRIPTION
resolve https://github.com/goplus/llcppg/issues/393

* log $platform-$arch-llcppg-$pkgname/$version.log to $LLCPPG_TEST_LOG_DIR or tempdir
* parallel test

expect fail   [3ac42c8](https://github.com/goplus/llcppg/pull/400/commits/3ac42c877ed4fdd679af3e99b0ec1e5e31587ec6) action https://github.com/goplus/llcppg/actions/runs/15410360485/job/43360893162?pr=400
![截屏2025-06-03 14 47 16](https://github.com/user-attachments/assets/51e5cace-1cc9-40f6-9e46-394f9f06c015)
