### PR TITLE
feat(symg):avoid list not global symbol

### DIFF
--- a/_xtool/llcppsymg/internal/symg/symg.go
+++ b/_xtool/llcppsymg/internal/symg/symg.go
@@ -133,7 +133,7 @@ func ParseDylibSymbols(lib string) ([]*nm.Symbol, error) {
 			continue
 		}
 
-		args := []string{}
+		args := []string{"-g"}
 		if runtime.GOOS == "linux" {
 			args = append(args, "-D")
 		}


### PR DESCRIPTION
* avoid nm list unuse symbol
* without -g libxslt got `ParseDylibSymbols: 3710 symbols` & with the -g we can got `ParseDylibSymbols: 2272 symbols` which is filter local symbol