### PR TITLE
chore(style): refine some error name

### DIFF
--- a/cl/internal/convert/package_test.go
+++ b/cl/internal/convert/package_test.go
@@ -1984,7 +1984,7 @@ func TestImport(t *testing.T) {
 		loader := convert.NewPkgDepLoader(mod, genPkg)
 		depPkgs, err := loader.LoadDeps(p.PkgInfo)
 		p.PkgInfo.Deps = depPkgs
-		if err != nil && !errors.Is(err, llcppg.ErrConfigError) {
+		if err != nil && !errors.Is(err, llcppg.ErrConfig) {
 			t.Fatal(err)
 		}
 		_, err = loader.Import("github.com/goplus/invalidpkg")
@@ -2028,7 +2028,7 @@ func TestImport(t *testing.T) {
 				},
 			},
 		})
-		if err != nil && !errors.Is(err, llcppg.ErrConfigError) {
+		if err != nil && !errors.Is(err, llcppg.ErrConfig) {
 			t.Fatal("NewPackage failed:", err)
 		}
 	})

--- a/config/config.go
+++ b/config/config.go
@@ -59,7 +59,7 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 
 	// when headeronly mode is disabled, libs must not be empty.
 	if c.Libs == "" && !c.HeaderOnly {
-		return fmt.Errorf("%w: libs must not be empty", ErrConfigError)
+		return fmt.Errorf("%w: libs must not be empty", ErrConfig)
 	}
 
 	return nil

--- a/config/error.go
+++ b/config/error.go
@@ -1,5 +1,5 @@
 package config
 
-import "fmt"
+import "errors"
 
-var ErrConfigError = fmt.Errorf("failed to unmarshal config")
+var ErrConfig = errors.New("failed to unmarshal config")


### PR DESCRIPTION
  According to the https://github.com/uber-go/guide/blob/master/style.md#error-types

 Since this is a static error message that needs error matching (used with errors.Is), errors.New is the recommended approach over `fmt.Errorf`.