### PR TITLE
refactor: standardize file permissions to 0644 for data files

### DIFF
--- a/_cmptest/llcppgend_test.go
+++ b/_cmptest/llcppgend_test.go
@@ -194,7 +194,7 @@ func testFrom(t *testing.T, tc testCase, isStatic bool, gen bool) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(processCfgPath, cfgContent, os.ModePerm)
+		err = os.WriteFile(processCfgPath, cfgContent, 0644)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/_xtool/internal/parser/parser_test.go
+++ b/_xtool/internal/parser/parser_test.go
@@ -67,7 +67,7 @@ func testFrom(t *testing.T, dir string, filename string, isCpp, gen bool) {
 	output, _ := json.MarshalIndent(&js, "", "  ")
 
 	if gen {
-		err = os.WriteFile(filepath.Join(dir, "expect.json"), output, os.ModePerm)
+		err = os.WriteFile(filepath.Join(dir, "expect.json"), output, 0644)
 		if err != nil {
 			t.Fatal("WriteFile failed:", err)
 		}

--- a/_xtool/llcppsigfetch/internal/parse/parse_test.go
+++ b/_xtool/llcppsigfetch/internal/parse/parse_test.go
@@ -89,7 +89,7 @@ func testFrom(t *testing.T, conf *parse.Config, dir string, gen bool) {
 
 	expectFile := filepath.Join(dir, "expect.json")
 	if gen {
-		err := os.WriteFile(expectFile, output, os.ModePerm)
+		err := os.WriteFile(expectFile, output, 0644)
 		if err != nil {
 			t.Fatal("WriteFile failed:", err)
 		}

--- a/_xtool/llcppsymg/internal/symg/symg_test.go
+++ b/_xtool/llcppsymg/internal/symg/symg_test.go
@@ -584,7 +584,7 @@ const char* test_function_3(void) {
 `
 
 	cSourcePath := filepath.Join(tempDir, "test.c")
-	err = os.WriteFile(cSourcePath, []byte(cSource), os.ModePerm)
+	err = os.WriteFile(cSourcePath, []byte(cSource), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/_xtool/llcppsymg/llcppsymg.go
+++ b/_xtool/llcppsymg/llcppsymg.go
@@ -86,7 +86,7 @@ func main() {
 	jsonData, err := json.MarshalIndent(symbolTable, "", "  ")
 	check(err)
 
-	err = os.WriteFile(llcppg.LLCPPG_SYMB, jsonData, os.ModePerm)
+	err = os.WriteFile(llcppg.LLCPPG_SYMB, jsonData, 0644)
 	check(err)
 }
 


### PR DESCRIPTION
  - Many files were using os.ModePerm which gives execute permissions (0777) to JSON, config, and source files
  - Data files like .json and .cfg shouldn't have execute permissions