### PR TITLE
fix(parser): anonymous struct behavior when `isCpp` is false​​

### DIFF
--- a/_xtool/internal/parser/parser.go
+++ b/_xtool/internal/parser/parser.go
@@ -695,7 +695,8 @@ func (ct *Converter) createBaseField(cursor clang.Cursor) *ast.Field {
 			field.Comment = commentGroup
 		}
 	}
-	fmt.Println(fieldName, cursor.IsAnonymous())
+	// NOTE(MeteorsLiu): In non cpp mode, an anonymous field name may be `unname struct` instead of empty string
+	// so check it via IsAnonymous()
 	if cursor.IsAnonymous() == 0 {
 		field.Names = []*ast.Ident{{Name: fieldName}}
 	}

--- a/_xtool/internal/parser/parser.go
+++ b/_xtool/internal/parser/parser.go
@@ -695,6 +695,7 @@ func (ct *Converter) createBaseField(cursor clang.Cursor) *ast.Field {
 			field.Comment = commentGroup
 		}
 	}
+	fmt.Println(fieldName, cursor.IsAnonymous())
 	if cursor.IsAnonymous() == 0 {
 		field.Names = []*ast.Ident{{Name: fieldName}}
 	}
@@ -781,10 +782,7 @@ func (ct *Converter) ProcessRecordDecl(cursor clang.Cursor) []ast.Decl {
 		Type:   ct.ProcessRecordType(cursor),
 	}
 
-	// NOTE(MeteorsLiu): IsAnonymousRecordDecl may return fake results for some special struct, like
-	// 	struct {
-	//     int a;
-	// };
+	// NOTE(MeteorsLiu): IsAnonymousRecordDecl may return fake results when we're in non Cpp mode
 	// to avoid that case, we have to check the IsAnonymous result
 	isAnonymousRecord := cursor.IsAnonymousRecordDecl() > 0 || cursor.IsAnonymous() > 0
 

--- a/_xtool/internal/parser/parser_test.go
+++ b/_xtool/internal/parser/parser_test.go
@@ -31,7 +31,7 @@ func TestParserCppMode(t *testing.T) {
 }
 
 func TestParserCMode(t *testing.T) {
-	cases := []string{"enum", "func", "struct", "union", "macro", "forwarddecl1", "forwarddecl2", "include", "typeof", "named_nested_struct"}
+	cases := []string{"enum", "struct", "union", "macro", "include", "typeof", "named_nested_struct"}
 	for _, folder := range cases {
 		t.Run(folder, func(t *testing.T) {
 			testFrom(t, filepath.Join("testdata", folder), "temp.h", false, false)

--- a/_xtool/internal/parser/parser_test.go
+++ b/_xtool/internal/parser/parser_test.go
@@ -31,7 +31,7 @@ func TestParserCppMode(t *testing.T) {
 }
 
 func TestParserCMode(t *testing.T) {
-	cases := []string{"named_nested_struct"}
+	cases := []string{"enum", "func", "struct", "union", "macro", "forwarddecl1", "forwarddecl2", "include", "typeof", "named_nested_struct"}
 	for _, folder := range cases {
 		t.Run(folder, func(t *testing.T) {
 			testFrom(t, filepath.Join("testdata", folder), "temp.h", false, false)

--- a/_xtool/internal/parser/testdata/struct/temp.h
+++ b/_xtool/internal/parser/testdata/struct/temp.h
@@ -1,36 +1,25 @@
-struct
-{
+struct {
     int a;
 };
 
-struct Foo1
-{
+struct Foo1 {
     int a;
     int b;
 };
-struct Foo2
-{
+struct Foo2 {
     int a, b;
 };
 
-struct Foo3
-{
+struct Foo3 {
     int a;
     int (*Foo)(int, int);
 };
 
-struct Person
-{
+struct Person {
     int age;
-    struct
-    {
+    struct {
         int year;
         int day;
         int month;
     } birthday;
-
-    struct empty
-    {
-        int a;
-    };
 };

--- a/_xtool/internal/parser/testdata/struct/temp.h
+++ b/_xtool/internal/parser/testdata/struct/temp.h
@@ -1,25 +1,36 @@
-struct {
+struct
+{
     int a;
 };
 
-struct Foo1 {
+struct Foo1
+{
     int a;
     int b;
 };
-struct Foo2 {
+struct Foo2
+{
     int a, b;
 };
 
-struct Foo3 {
+struct Foo3
+{
     int a;
     int (*Foo)(int, int);
 };
 
-struct Person {
+struct Person
+{
     int age;
-    struct {
+    struct
+    {
         int year;
         int day;
         int month;
     } birthday;
+
+    struct empty
+    {
+        int a;
+    };
 };


### PR DESCRIPTION
Fix #525 