### PR TITLE
docs: wrap config file names with backticks in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ go install .
 
 ## Usage
 
-llcppg.cfg file is a configure file used by llcppg. Once llcppg.cfg is generated then you can run llcppg command to generate go pacakge for the c/c++ lib.
+`llcppg.cfg` file is a configure file used by llcppg. Once `llcppg.cfg` is generated then you can run llcppg command to generate go pacakge for the c/c++ lib.
 
 ```sh
 llcppg [config-file]
@@ -69,13 +69,13 @@ The configuration file supports the following options:
 After creating the configuration file, run:
 
 ```bash
-llcppg llcppg.cfg
+llcppg `llcppg.cfg`
 ```
 
 If you're not in a Go module or want to create a separate module, you can use the `-mod` flag to create a new Go module for the generated package:
 
 ```bash
-llcppg -mod github.com/author/cjson llcppg.cfg
+llcppg -mod github.com/author/cjson `llcppg.cfg`
 ```
 
 After execution,LLGo Binding will be generated in a directory named after the config name (which is also the package name). For example, with the cjson configuration above, you'll see:
@@ -85,7 +85,7 @@ cjson/
 ├── cJSON.go
 ├── cJSON_Utils.go
 ├── cjson_autogen_link.go
-├── llcppg.pub
+├── `llcppg.pub`
 ├── go.mod  # Contains: module github.com/author/cjson (only when using -mod flag)
 └── go.sum  # Contains dependency checksums (only when using -mod flag)
 ```
@@ -358,8 +358,8 @@ xmlChar * xsltGetNsProp(xmlNodePtr node, const xmlChar *name, const xmlChar *nam
 If `xmlChar` and `xmlNodePtr` mappings are not found (not declare `llcppg-libxml` in `deps`), llcppg will notify the user of these missing types and indicate they are from `libxml2` header files.
 The corresponding notification would be:
 ```bash
-convert /path/to/include/libxml2/libxml/xmlstring.h first, declare its converted package in llcppg.cfg deps for load [xmlChar].
-convert /path/to/libxml2/libxml/tree.h first, declare its converted package in llcppg.cfg deps for load [xmlNodePtr].
+convert /path/to/include/libxml2/libxml/xmlstring.h first, declare its converted package in `llcppg.cfg` deps for load [xmlChar].
+convert /path/to/libxml2/libxml/tree.h first, declare its converted package in `llcppg.cfg` deps for load [xmlNodePtr].
 ```
 
 For this project, `llcppg` will automatically handle type references to libxml2. During the process, `llcppg` uses the `llcppg.pub` file from the generated libxml2 package to ensure type consistency.
@@ -453,7 +453,7 @@ This caching strategy ensures that type references are properly maintained when 
 llcppcfg [libname]
 ```
 
-llcppcfg tool is used to generate llcppg.cfg file.
+llcppcfg tool is used to generate `llcppg.cfg` file.
 
 ## Design
 

--- a/doc/en/dev/llcppcfg.md
+++ b/doc/en/dev/llcppcfg.md
@@ -1,5 +1,5 @@
 # Abstract
-The llcppg core configuration file, llcppg.cfg, can be complex and error-prone to configure. This is because it requires a deep understanding of the project structure and compilation details. We have designed llcppcfg to automatically generate the basic llcppg.cfg configuration file for users. It greatly simplifies the configuration process, allowing users to simply provide the target library's name as input. The tool then generates corresponding configuration content based on established rules or templates.
+The llcppg core configuration file, `llcppg.cfg`, can be complex and error-prone to configure. This is because it requires a deep understanding of the project structure and compilation details. We have designed llcppcfg to automatically generate the basic `llcppg.cfg` configuration file for users. It greatly simplifies the configuration process, allowing users to simply provide the target library's name as input. The tool then generates corresponding configuration content based on established rules or templates.
 
 # Basic Usage
 `llcppcfg [options] <library actual PC name>`
@@ -7,7 +7,7 @@ The llcppg core configuration file, llcppg.cfg, can be complex and error-prone t
 ## Example of Generating Configuration File
 `llcppcfg cjson`
 
-This command will generate the llcppg.cfg configuration file in the current directory.
+This command will generate the `llcppg.cfg` configuration file in the current directory.
 
 ## Command Line Option Details
 
@@ -38,7 +38,7 @@ After executing the following command:
 
 `llcppcfg -cpp -deps="github.com/goplus/llpkg/zlib@v1.0.2" -exts=".h .hpp" openssl`
 
-The generated llcppg.cfg content will be similar to:
+The generated `llcppg.cfg` content will be similar to:
 
 ```json
 {

--- a/doc/en/dev/llcppg.md
+++ b/doc/en/dev/llcppg.md
@@ -451,10 +451,10 @@ Each dependency package follows a unified file organization structure (using xml
 1. HTMLtree.go (generated from HTMLtree.h)
 2. HTMLparser.go (generated from HTMLparser.h)
 * Configuration files
-1. llcppg.cfg (dependency information)
-2. llcppg.pub (type mapping information)
+1. `llcppg.cfg` (dependency information)
+2. `llcppg.pub` (type mapping information)
 
-##### TypeMapping Examples (llcppg.pub)
+##### TypeMapping Examples (`llcppg.pub`)
 
 * C types on the left and corresponding Go type names on the right
 * If the Go Name is same with C type name,only need keep one column
@@ -513,8 +513,8 @@ xmlChar * xsltGetNsProp(xmlNodePtr node, const xmlChar *name, const xmlChar *nam
 If `xmlChar` and `xmlNodePtr` mappings are not found (not declare `llcppg-libxml` in `deps`), llcppg will notify the user of these missing types and indicate they are from `libxml2` header files.
 The corresponding notification would be:
 ```bash
-convert /path/to/include/libxml2/libxml/xmlstring.h first, declare its converted package in llcppg.cfg deps for load [xmlChar].
-convert /path/to/libxml2/libxml/tree.h first, declare its converted package in llcppg.cfg deps for load [xmlNodePtr].
+convert /path/to/include/libxml2/libxml/xmlstring.h first, declare its converted package in `llcppg.cfg` deps for load [xmlChar].
+convert /path/to/libxml2/libxml/tree.h first, declare its converted package in `llcppg.cfg` deps for load [xmlNodePtr].
 ```
 
 For this project, `llcppg` will automatically handle type references to libxml2. During the process, `llcppg` uses the `llcppg.pub` file from the generated libxml2 package to ensure type consistency.
@@ -690,7 +690,7 @@ import (
 
 ### Type Mapping File
 
-* Generates an llcppg.pub file containing a mapping table from C types to Go type names, is used for package dependency handling, example and concept see [Dependency](#Dependency)
+* Generates an `llcppg.pub` file containing a mapping table from C types to Go type names, is used for package dependency handling, example and concept see [Dependency](#Dependency)
 
 ### Go Module Files (Optional)
 
@@ -721,7 +721,7 @@ cjson/
 ├── cJSON.go                    # Bindings generated from cJSON.h
 ├── cJSON_Utils.go             # Bindings generated from cJSON_Utils.h
 ├── cjson_autogen_link.go      # Auto-generated link file
-├── llcppg.pub                 # Type mapping information
+├── `llcppg.pub`                 # Type mapping information
 ├── go.mod                     # Go module file (when using -mod flag)
 └── go.sum                     # Dependency checksums (when using -mod flag)
 ```
@@ -756,7 +756,7 @@ When `staticLib: true` is configured in `llcppg.cfg`, llcppsymg switches to stat
 
 #### Header-Only Mode
 
-When `headerOnly: true` is configured in llcppg.cfg, llcppg operates in header-only processing mode.
+When `headerOnly: true` is configured in `llcppg.cfg`, llcppg operates in header-only processing mode.
 
 In header-only processing mode, instead of matching library symbols with header declarations, it will generate the symbol table based solely on header files specified in cflags.
 
@@ -866,7 +866,7 @@ gogensig -  # read pkg-info-file from stdin
 ```
 
 #### Function Generation
-During execution, gogensig only generates functions whose corresponding mangle exists in llcppg.symb.json, determining whether to generate functions/methods with specified Go names by parsing the go field corresponding to the mangle.
+During execution, gogensig only generates functions whose corresponding mangle exists in `llcppg.symb.json`, determining whether to generate functions/methods with specified Go names by parsing the go field corresponding to the mangle.
 
 1. Regular function format: "FunctionName"
   * Generates regular functions, using `//go:linkname` annotation


### PR DESCRIPTION
- Wrap llcppg.cfg, llcppg.symb.json, and llcppg.pub with backticks
- Updated README.md, llcppcfg.md, and llcppg.md for consistency
- Fixes issue #544

🤖 Generated with [Claude Code](https://claude.ai/code)