### PR TITLE
Fix JSON field name in README.md: change 'includes' to 'include'

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ You can specify dependent package paths in the `deps` field of `llcppg.cfg` . Fo
   "libs": "$(pkg-config --libs libxslt)",
   "trimPrefixes": ["xslt"],
   "deps": ["c/os","github.com/goplus/llpkg/libxml2"],
-  "includes":["libxslt/xsltutils.h","libxslt/templates.h"]
+  "include":["libxslt/xsltutils.h","libxslt/templates.h"]
 }
 ```
 


### PR DESCRIPTION
## Summary
Fixed inconsistent JSON field name in README.md where 'includes' should be 'include' to match the documented configuration format.

## Changes
- Changed 'includes' to 'include' in the libxslt configuration example on line 347

## Context
All configuration files throughout the codebase use 'include' as the field name for specifying header files, not 'includes'. This change ensures consistency with:
- The actual libxslt configuration file in `_llcppgtest/libxslt/llcppg.cfg`
- All other configuration examples in the documentation
- The configuration format specification

## Related Issue
Fixes #549

🤖 Generated with [Claude Code](https://claude.ai/code)