### PR TITLE
docs: Fix typos in documentation and code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ The configuration file supports the following options:
 - `include`: Header files to include in the binding generation
 - `libs`: Library flags for linking
 - `trimPrefixes`: Prefixes to remove from function names & type names
-- `cplusplus`: Set to true for C++ libraries(not support)
+- `cplusplus`: Set to true for C++ libraries (not supported)
 - `deps`: Dependencies (other packages & standard libraries)
 - `mix`: Set to true when package header files are mixed with other header files in the same directory. In this mode, only files explicitly listed in `include` are processed as package files.
 - `typeMap`: Custom name mapping from C types to Go types.
 - `symMap`: Custom name mapping from C function names to Go function names.
 - `staticLib`: Set to true to enable static library symbol reading instead of dynamic library linking. When enabled, llcppg will read symbols from static libraries (.a files) rather than dynamic libraries (.so/.dylib files).
-- `headerOnly`: Set to true to ​​enable header-only mode. In header-only processing mode, instead of matching library symbols with header declarations, it will generate the symbol table based solely on header files specified in cflags.
+- `headerOnly`: Set to true to enable header-only mode. In header-only processing mode, instead of matching library symbols with header declarations, it will generate the symbol table based solely on header files specified in cflags.
 
 After creating the configuration file, run:
 
@@ -78,7 +78,7 @@ If you're not in a Go module or want to create a separate module, you can use th
 llcppg -mod github.com/author/cjson llcppg.cfg
 ```
 
-After execution,LLGo Binding will be generated in a directory named after the config name (which is also the package name). For example, with the cjson configuration above, you'll see:
+After execution, LLGo Binding will be generated in a directory named after the config name (which is also the package name). For example, with the cjson configuration above, you'll see:
 
 ```bash
 cjson/

--- a/cl/internal/convert/funcname.go
+++ b/cl/internal/convert/funcname.go
@@ -14,7 +14,7 @@ import (
 type GoFuncSpec struct {
 	GoSymbName string // original full name from input
 	FnName     string // function name without receiver
-	IsMethod   bool   // if the function canbe a method
+	IsMethod   bool   // if the function can be a method
 	RecvName   string // receiver name
 	PtrRecv    bool   // if the receiver is a pointer
 }
@@ -35,7 +35,7 @@ func NewGoFuncSpec(name string, field []*ast.Field) *GoFuncSpec {
 		recvName = strings.TrimSuffix(recvName, ")")
 	}
 
-	// if the function cant be a method, we use the function name as the Go symbol name
+	// if the function can't be a method, we use the function name as the Go symbol name
 	// not use the receiver style to link
 	fnName := l[1]
 	goSymbName := name

--- a/doc/en/dev/llcppcfg.md
+++ b/doc/en/dev/llcppcfg.md
@@ -79,4 +79,4 @@ The generated llcppg.cfg content will be similar to:
 
 4. **Sort by Dependency Weight**
    Prioritize headers based on:
-   - Dependency count (files with more dependencies rank higher)
+   - Dependency count (files with more dependencies rank higher).


### PR DESCRIPTION
## Summary
Fixed spelling and grammar errors found throughout the project documentation and code comments as requested in issue #540.

## Changes Made

### README.md
- Fixed "(not support)" → "(not supported)" - added missing space and corrected grammar
- Removed zero-width characters from headerOnly description that were causing display issues
- Added missing space in "After execution,LLGo" → "After execution, LLGo"

### doc/en/dev/llcppcfg.md
- Added missing period after "rank higher)" to complete the sentence

### cl/internal/convert/funcname.go
- Fixed "canbe" → "can be" in struct field comment
- Fixed "cant" → "can't" in function comment

## Review Process
- Systematically searched for common spelling errors across all documentation files
- Checked code comments in Go files for typos
- Found and fixed 6 distinct issues across 3 files
- Focused only on documentation and comments as specified in the issue

## Related Issue
Fixes #540

🤖 Generated with [Claude Code](https://claude.ai/code)