### PR TITLE
Fix punctuation spacing in Go code comments

### DIFF
--- a/_xtool/internal/header/header.go
+++ b/_xtool/internal/header/header.go
@@ -25,7 +25,7 @@ type Config struct {
 	// - "zlib.h"
 	// - "openssl/ssl.h"
 	Includes []string
-	// PlatDiff specifies header file include paths that differ between platforms,these are include paths in Includes.
+	// PlatDiff specifies header file include paths that differ between platforms, these are include paths in Includes.
 	PlatDiff []string
 	Args     []string
 	Mix      bool

--- a/_xtool/internal/parser/parser.go
+++ b/_xtool/internal/parser/parser.go
@@ -201,7 +201,7 @@ func (ct *Converter) ParseComment(rawComment string) *ast.CommentGroup {
 	return commentGroup
 }
 
-// visit top decls (struct,class,function,enum & macro,include)
+// visit top decls (struct, class, function, enum & macro, include)
 func (ct *Converter) visitTop(cursor, parent clang.Cursor) clang.ChildVisitResult {
 	ct.incIndent()
 	defer ct.decIndent()
@@ -273,7 +273,7 @@ func (ct *Converter) visitTop(cursor, parent clang.Cursor) clang.ChildVisitResul
 	return clang.ChildVisit_Continue
 }
 
-// for flatten ast,keep type order
+// for flatten ast, keep type order
 // input is clang -E 's result
 func (ct *Converter) Convert() (*ast.File, error) {
 	cursor := ct.unit.Cursor()
@@ -508,7 +508,7 @@ func (ct *Converter) ProcessFuncDecl(cursor clang.Cursor) *ast.FuncDecl {
 	ct.logln("ProcessFuncDecl: CursorName:", name, "CursorKind:", kind, "mangledName:", mangledName)
 
 	// function type will only collect return type
-	// ProcessType can't get the field names,will collect in follows
+	// ProcessType can't get the field names, will collect in follows
 	fnType := cursor.Type()
 	typName, typKind := getTypeDesc(fnType)
 	ct.logln("ProcessFuncDecl: TypeName:", typName, "TypeKind:", typKind)
@@ -703,7 +703,7 @@ func (ct *Converter) createBaseField(cursor clang.Cursor) *ast.Field {
 	return field
 }
 
-// For Record Type(struct,union ...)'s FieldList
+// For Record Type(struct, union ...)'s FieldList
 func (ct *Converter) ProcessFieldList(cursor clang.Cursor) *ast.FieldList {
 	ct.incIndent()
 	defer ct.decIndent()

--- a/_xtool/llcppsymg/internal/symg/parse.go
+++ b/_xtool/llcppsymg/internal/symg/parse.go
@@ -158,7 +158,7 @@ func (p *SymbolProcessor) genGoName(cursor clang.Cursor, symbolName string) stri
 		return customGoName
 	}
 
-	// 1. for class method,gen method name
+	// 1. for class method, gen method name
 	if parent := cursor.SemanticParent(); parent.Kind == clang.CursorClassDecl {
 		class := name.GoName(clang.GoString(parent.String()), p.prefixes, p.inCurPkg(cursor))
 		// concat method name
@@ -172,9 +172,9 @@ func (p *SymbolProcessor) genGoName(cursor clang.Cursor, symbolName string) stri
 	numArgs := cursor.NumArguments()
 	// 3. Don't attempt to convert a variadic function to a method
 	isValist := cursor.Type().IsFunctionTypeVariadic() > 0
-	// also config to gen method name,if can't gen method,use the origin function type
+	// also config to gen method name, if can't gen method, use the origin function type
 	if numArgs > 0 && !isValist {
-		// also can gen method name,but not want to be method,output func not method
+		// also can gen method name, but not want to be method, output func not method
 		if isCustom && !toMethod {
 			return p.AddSuffix(customGoName)
 		}
@@ -281,7 +281,7 @@ func (p *SymbolProcessor) processCollect() {
 }
 
 // Get the underlying cursor of the cursor
-// if cur is a pointer,return the underlying cursor
+// if cur is a pointer, return the underlying cursor
 func underCursor(arg clang.Cursor) clang.Cursor {
 	typ := arg.Type()
 	if typ.Kind == clang.TypePointer {
@@ -291,7 +291,7 @@ func underCursor(arg clang.Cursor) clang.Cursor {
 }
 
 // https://releases.llvm.org/19.1.0/tools/clang/docs/ReleaseNotes.html#libclang
-// cursor.Location() in llvm@19 cannot get the fileinfo for a macro expansion,so we dirrect use PresumedLocation
+// cursor.Location() in llvm@19 cannot get the fileinfo for a macro expansion, so we dirrect use PresumedLocation
 func cursorFileName(cursor clang.Cursor) string {
 	loc := cursor.Location()
 	filePath, _, _ := clangutils.GetPresumedLocation(loc)

--- a/cl/internal/convert/package.go
+++ b/cl/internal/convert/package.go
@@ -51,7 +51,7 @@ type PackageConfig struct {
 	GenConf   *gogen.Config
 
 	// use to gen link command like $(pkg-config --libs xxx)
-	// if have this field,will generate a const named LLGoPackage,and it's not necessary
+	// if have this field, will generate a const named LLGoPackage, and it's not necessary
 	LibCommand string
 }
 
@@ -160,8 +160,8 @@ func (p *Package) bodyStart(decl *gogen.Func, ret ast.Expr) error {
 		}
 
 		if asStruct(retType) {
-			// use empty named struct type to return,without this solution,we will get a anonymous struct type
-			// and it will cause a compile error,like following:
+			// use empty named struct type to return, without this solution, we will get a anonymous struct type
+			// and it will cause a compile error, like following:
 			// func (recv *Vector3) Vector3Barycenter(p Vector3, a Vector3, b Vector3, c Vector3) Vector3 {
 			// 	return struct {
 			// 		x c.Int
@@ -169,7 +169,7 @@ func (p *Package) bodyStart(decl *gogen.Func, ret ast.Expr) error {
 			// 		z c.Int
 			// 	}{}
 			// }
-			// this result will cause the `c` in the return type is use the `c` in the parameter,which is not have the `Int`
+			// this result will cause the `c` in the return type is use the `c` in the parameter, which is not have the `Int`
 			decl.BodyStart(p.p).StructLit(retType, 0, true).Return(1).End()
 			return nil
 		}
@@ -286,7 +286,7 @@ func (p *Package) funcIsDefined(fnSpec *GoFuncSpec, funcDecl *ast.FuncDecl) (rec
 		name: funcDecl.Name.Name,
 		kind: FuncDecl,
 	}
-	// if already processed,return
+	// if already processed, return
 	_, exist = p.symbols.Lookup(node)
 	if exist {
 		return nil, true, nil
@@ -299,7 +299,7 @@ func (p *Package) funcIsDefined(fnSpec *GoFuncSpec, funcDecl *ast.FuncDecl) (rec
 		var namedType = getNamedType(recv.Type())
 		methodName := fnSpec.FnName
 		for i := 0; i < namedType.NumMethods(); i++ {
-			if namedType.Method(i).Name() == methodName { // unreachable,because if have the same method name,will return in p.symbols.Lookup(node)
+			if namedType.Method(i).Name() == methodName { // unreachable, because if have the same method name, will return in p.symbols.Lookup(node)
 				return nil, true, fmt.Errorf("NewFuncDecl: %s already defined", fnSpec.GoSymbName)
 			}
 		}
@@ -364,8 +364,8 @@ func (p *Package) NewTypeDecl(goName string, typeDecl *ast.TypeDecl, pnc nc.Node
 		return fmt.Errorf("NewTypeDecl: %s fail: %w", typeDecl.Name.Name, err)
 	}
 
-	// if the type is already defined,we don't need to process again
-	// but if the previous processed node is a forward declaration,we need to complete the type
+	// if the type is already defined, we don't need to process again
+	// but if the previous processed node is a forward declaration, we need to complete the type
 	_, isIncom := p.incompleteTypes.Lookup(typeDecl.Name.Name)
 	if exist && (isForward || !isIncom) {
 		if debugLog {
@@ -837,7 +837,7 @@ type Node struct {
 }
 
 type ProcessSymbol struct {
-	// not same node can have same name,so use the Node as key
+	// not same node can have same name, so use the Node as key
 	info  map[Node]string
 	count map[string]int
 }

--- a/cl/internal/convert/type.go
+++ b/cl/internal/convert/type.go
@@ -93,7 +93,7 @@ func (p *TypeConv) handleArrayType(t *ast.ArrayType) (types.Type, error) {
 		return nil, fmt.Errorf("error convert elem type: %w", err)
 	}
 	if p.ctx == Param {
-		// array in the parameter,ignore the len,convert as pointer
+		// array in the parameter, ignore the len, convert as pointer
 		return types.NewPointer(elemType), nil
 	}
 

--- a/cl/nc/ncimpl/ncimpl.go
+++ b/cl/nc/ncimpl/ncimpl.go
@@ -71,7 +71,7 @@ func (p *Converter) ConvDecl(file string, decl ast.Decl) (goName, goFile string,
 	switch decl := decl.(type) {
 	case *ast.FuncDecl:
 		goName, err = p.ConvSym(obj, decl.MangledName)
-		// only have error when symbol not found,current keep only log this error
+		// only have error when symbol not found, current keep only log this error
 		if err != nil {
 			log.Printf("ConvDecl: %s not found in symbolmap: %s", decl.MangledName, err.Error())
 			err = nc.ErrSkip

--- a/internal/name/name.go
+++ b/internal/name/name.go
@@ -63,7 +63,7 @@ func ToCamelCase(s string, firstPartUpper bool) string {
 	return strings.Join(result, "")
 }
 
-// Only Make it Public,no turn to other camel method
+// Only Make it Public, no turn to other camel method
 func ExportName(name string) string {
 	fChar := name[0]
 	if fChar == '_' || unicode.IsDigit(rune(fChar)) {


### PR DESCRIPTION
## Summary
- Fix missing spaces after commas in Go code comments
- Improve readability and consistency of code comments
- Follow standard English punctuation rules

## Files Changed
- `internal/name/name.go`: Fix comma spacing in comment
- `cl/nc/ncimpl/ncimpl.go`: Fix comma spacing in comment  
- `cl/internal/convert/package.go`: Fix multiple comma spacing issues in comments
- `cl/internal/convert/type.go`: Fix comma spacing in comment
- `_xtool/internal/parser/parser.go`: Fix comma spacing in multiple comments
- `_xtool/llcppsymg/internal/symg/parse.go`: Fix comma spacing in multiple comments  
- `_xtool/internal/header/header.go`: Fix comma spacing in comment

## Details
Fixed 22 instances of missing spaces after commas in Go code comments, improving code readability and consistency with standard English punctuation rules.