### PR TITLE
ci: optimize workflows to skip documentation-only changes

### DIFF
--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -3,8 +3,14 @@ name: Test Result End2End
 on:
   push:
     branches: [ "**" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   pull_request:
     branches: [ "**" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
 

--- a/.github/workflows/gentest.yml
+++ b/.github/workflows/gentest.yml
@@ -3,8 +3,14 @@ name: Test Demo With Generated Pkgs
 on:
   push:
     branches: [ "**" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   pull_request:
     branches: [ "**" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,8 +6,14 @@ name: Go
 on:
   push:
     branches: [ "**" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   pull_request:
     branches: [ "**" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
 


### PR DESCRIPTION
## Summary
- Add path filters to GitHub Actions workflows to skip CI execution when only documentation files are modified
- Affects all three workflows: go.yml, end2end.yml, and gentest.yml
- Add `paths-ignore` for `**.md` and `docs/**` patterns

## Test plan
- [x] Verify workflow syntax is correct
- [ ] Test with documentation-only PR to confirm CI is skipped
- [ ] Test with code changes to ensure CI still runs

Closes #555

🤖 Generated with [Claude Code](https://claude.ai/code)