### PR TITLE
chore(ci): migrate from `macos-13` to `macos-15-intel` runner

### DIFF
--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-13
+          - macos-15-intel
           - macos-latest
-          - ubuntu-24.04
+          - ubuntu-latest
           - ubuntu-24.04-arm
         llvm: [19]
         llgo: [e4218f90d7926d31c1ffae3965a4e36228d38fd2]

--- a/.github/workflows/gentest.yml
+++ b/.github/workflows/gentest.yml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-13
+          - macos-15-intel
           - macos-latest
-          - ubuntu-24.04
+          - ubuntu-latest
           - ubuntu-24.04-arm
         llvm: [19]
         llgo: [e4218f90d7926d31c1ffae3965a4e36228d38fd2]

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-24.04
+          - ubuntu-latest
         llvm: [19]
         llgo: [e4218f90d7926d31c1ffae3965a4e36228d38fd2]
         go: [1.23]


### PR DESCRIPTION
GitHub announced the deprecation of the `macos-13` runner image[^1], which will be completely removed by December 4th, 2025.

This commit migrates all workflows to use `macos-15-intel` runners following the announcement's recommendation.

This also uses `ubuntu-latest` alias instead of explicit `ubuntu-24.04`.

[^1]: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/