### PR TITLE
ci: remove unnecessary Python setup from macOS CI

### DIFF
--- a/.github/actions/setup-llcppg/action.yml
+++ b/.github/actions/setup-llcppg/action.yml
@@ -30,10 +30,8 @@ runs:
     run: |
       brew install llvm@${{inputs.llvm}} bdw-gc openssl libffi libuv lld@${{inputs.llvm}}
       brew install zlib # for llgo test .
-      brew install python@3.12 || true # for github.com/goplus/lib/py
       brew link --force zlib # for llgo test .
       brew link --force libffi
-      brew link --overwrite python@3.12
       echo "$(brew --prefix llvm@${{inputs.llvm}})/bin" >> $GITHUB_PATH
       echo "$(brew --prefix lld@${{inputs.llvm}})/bin" >> $GITHUB_PATH
   - name: Install dependencies

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -75,14 +75,4 @@ jobs:
         slug: goplus/llcppg
 
     - name: Test demos
-      run: |
-        # TODO(lijie): force python3-embed to be linked with python-3.12-embed
-        # Currently, python3-embed is python-3.13-embed, doesn't work with pytorch
-        # Will remove this after pytorch is fixed.
-        pcdir=$HOME/pc
-        mkdir -p $pcdir
-        libdir=$(pkg-config --variable=libdir python-3.12-embed)
-        echo "libdir: $libdir"
-        ln -s $libdir/pkgconfig/python-3.12-embed.pc $pcdir/python3-embed.pc
-        export PKG_CONFIG_PATH=$pcdir
-        bash .github/workflows/test_demo.sh
+      run: bash .github/workflows/test_demo.sh


### PR DESCRIPTION
## Summary

Fixes #585 

Remove unnecessary Python 3.12 setup from macOS CI that was causing demo tests to fail with exit code 1.

## Changes

**`.github/actions/setup-llcppg/action.yml`**
- Remove `brew install python@3.12 || true`
- Remove `brew link --overwrite python@3.12`

**`.github/workflows/go.yml`**
- Remove entire Python symlink setup block (12 lines)
- Simplify "Test demos" step to directly run the test script

## Why This Works

The original code attempted to create a symlink for `python3-embed` pointing to `python-3.12-embed` for PyTorch compatibility. However:

1. The project has no `_pydemo` directory
2. Only `_demo/cjsondemo` exists, which doesn't require Python
3. The `pkg-config --variable=libdir python-3.12-embed` command was failing because Python 3.12 wasn't installed
4. This caused the entire "Test demos" step to exit early with code 1

## Benefits

- ✅ Fixes macOS-latest CI failures
- ✅ Simplifies CI configuration  
- ✅ Faster build times (no Python installation)
- ✅ Removes unused dependencies

## Test Plan

- [ ] Verify CI passes on macOS-latest
- [ ] Confirm demo tests run successfully
- [ ] Check that cjsondemo still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)