### PR TITLE
demo:update to libxml2v2.15 use

### DIFF
--- a/_llcppgtest/libxml2/demo/parsexml/parsexml.go
+++ b/_llcppgtest/libxml2/demo/parsexml/parsexml.go
@@ -17,6 +17,6 @@ func main() {
 	docPtr := (*libxml2.XmlDoc)(unsafe.Pointer(doc))
 	root := docPtr.XmlDocGetRootElement()
 	c.Printf(c.Str("Root element: %s\n"), root.Name)
-	libxml2.XmlFreeDoc(doc)
+	doc.XmlFreeDoc()
 	libxml2.XmlCleanupParser()
 }


### PR DESCRIPTION
fixed https://github.com/goplus/llcppg/issues/601

 libxml2v2.15 's xmlFreeDoc
```go
// llgo:link (*XmlDoc).XmlFreeDoc C.xmlFreeDoc
func (recv_ *XmlDoc) XmlFreeDoc() {
}
```