### PR TITLE
docs: clarify llgo main-branch install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ llcppg - LLGo autogen tool for C/C++ libraries
 [![Language](https://img.shields.io/badge/language-XGo-blue.svg)](https://github.com/goplus/gop)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/goplus/llcppg)
 
-llcppg aims to automatically generate LLGo bindings for C/C++ libraries and improve the LLGo + C integration experience.
-The full llcppg package-generation pipeline is now built and orchestrated with LLGo.
+llcppg aims to be a tool for automatically generating LLGo bindings for C/C++ libraries, enhancing the experience of integrating LLGo with C!
+It is worth mentioning that the full llcppg package-generation pipeline is now built and orchestrated with LLGo.
 
 ## How to install
 


### PR DESCRIPTION
## Summary
- update `README.md` install section to explicitly state that the current end-to-end llcppg package-generation pipeline is compiled by LLGo
- clarify that llcppg tracks LLGo `main` behavior and should be installed with an LLGo build from the `main` branch
- streamline install commands in the README:
  - keep `llgo install ./cmd/llcppg` as the primary required command
  - keep standalone tools (`llcppsymg`, `llcppsigfetch`, `gogensig`, `llcppcfg`) as optional debug/troubleshooting installs
  - remove `llcppgtest` from the install section

## Why
Recent pipeline changes made llcppg generation fully LLGo-driven. The README should reflect this explicitly to avoid version mismatch and installation confusion.

## Scope
Documentation-only change. No code or behavior changes.
