### PR TITLE
docs: refine README install flow and devtool section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ llgo install ./cmd/llcppg
 
 For normal package generation, only the `llcppg` binary is required.
 
-### devtool
+### Development tools
 
 For debugging and isolated troubleshooting, you can optionally install these standalone tools:
 


### PR DESCRIPTION
## Summary
- update the README install section to clarify that the llcppg package-generation pipeline is fully compiled by LLGo
- clarify that llcppg currently follows LLGo `main` branch behavior
- keep the minimal required install command for normal usage:
  - `llgo install ./cmd/llcppg`
- move optional standalone tools into a separate `devtool` subsection under **How to install**:
  - `llgo install ./_xtool/llcppsymg`
  - `llgo install ./_xtool/llcppsigfetch`
  - `llgo install ./cmd/gogensig`
  - `go install ./cmd/llcppcfg`

## Scope
Documentation-only update. No code behavior changes.
