### PR TITLE
build(deps): bump gogen to v1.23.3

### DIFF
--- a/_llcppgtest/lua/conf/linux/llcppg.cfg
+++ b/_llcppgtest/lua/conf/linux/llcppg.cfg
@@ -9,6 +9,9 @@
 		"lauxlib.h"
 	],
 	"trimPrefixes": ["lua_", "luaopen_", "luaL_", "LUA_T", "LUA_"],
+	"symMap": {
+		"luaL_alloc": "LuaLAlloc"
+	},
 	"cplusplus": false,
 	"mix":true
 }

--- a/_llcppgtest/lua/demo/hello/hello.go
+++ b/_llcppgtest/lua/demo/hello/hello.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	L := lua.Newstate__1()
 	defer L.Close()
-	L.Openlibs()
+	openlibs(L)
 	if res := L.Loadstring(c.Str("print('hello world')")); res != lua.OK {
 		panic("error")
 	}

--- a/_llcppgtest/lua/demo/hello/openlibs_darwin.go
+++ b/_llcppgtest/lua/demo/hello/openlibs_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package main
+
+import "lua"
+
+func openlibs(L *lua.State) {
+	L.Openselectedlibs(-1, 0)
+}

--- a/_llcppgtest/lua/demo/hello/openlibs_other.go
+++ b/_llcppgtest/lua/demo/hello/openlibs_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package main
+
+import "lua"
+
+func openlibs(L *lua.State) {
+	L.Openlibs()
+}

--- a/_llcppgtest/lua/demo/loadcall/loadcall.go
+++ b/_llcppgtest/lua/demo/loadcall/loadcall.go
@@ -12,7 +12,7 @@ func main() {
 	L := lua.Newstate__1()
 	defer L.Close()
 
-	L.Openlibs()
+	openlibs(L)
 	if res := L.Loadstring(c.Str("print('hello world')")); res != lua.OK {
 		println("error")
 	}

--- a/_llcppgtest/lua/demo/loadcall/openlibs_darwin.go
+++ b/_llcppgtest/lua/demo/loadcall/openlibs_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package main
+
+import "lua"
+
+func openlibs(L *lua.State) {
+	L.Openselectedlibs(-1, 0)
+}

--- a/_llcppgtest/lua/demo/loadcall/openlibs_other.go
+++ b/_llcppgtest/lua/demo/loadcall/openlibs_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package main
+
+import "lua"
+
+func openlibs(L *lua.State) {
+	L.Openlibs()
+}

--- a/_llcppgtest/lua/demo/metatable/metatable.go
+++ b/_llcppgtest/lua/demo/metatable/metatable.go
@@ -33,7 +33,7 @@ func main() {
 	L := lua.Newstate__1()
 	defer L.Close()
 
-	L.Openlibs()
+	openlibs(L)
 
 	L.Createtable(0, 0)
 	printStack(L, "After creating main table")

--- a/_llcppgtest/lua/demo/metatable/openlibs_darwin.go
+++ b/_llcppgtest/lua/demo/metatable/openlibs_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package main
+
+import "lua"
+
+func openlibs(L *lua.State) {
+	L.Openselectedlibs(-1, 0)
+}

--- a/_llcppgtest/lua/demo/metatable/openlibs_other.go
+++ b/_llcppgtest/lua/demo/metatable/openlibs_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package main
+
+import "lua"
+
+func openlibs(L *lua.State) {
+	L.Openlibs()
+}

--- a/_llcppgtest/lua/llcppg.cfg
+++ b/_llcppgtest/lua/llcppg.cfg
@@ -9,5 +9,8 @@
 		"lauxlib.h"
 	],
 	"trimPrefixes": ["lua_", "luaopen_", "luaL_", "LUA_T", "LUA_"],
+	"symMap": {
+		"luaL_alloc": "LuaLAlloc"
+	},
 	"cplusplus": false
 }

--- a/cl/decl.go
+++ b/cl/decl.go
@@ -76,7 +76,7 @@ func compileFuncDecl(ctx *blockCtx, fn *ast.FuncDecl) {
 		}
 		pkg := ctx.pkg
 		if tyRet := toType(ctx, fnType, parser.FlagGetRetType); ctypes.NotVoid(tyRet) {
-			results = types.NewTuple(pkg.NewParam(token.NoPos, "", tyRet))
+			results = types.NewTuple(pkg.NewParam(token.NoPos, "", tyRet, false))
 		}
 		/* TODO(xsw): check
 		sig := gogen.NewCSignature(types.NewTuple(params...), results, variadic)
@@ -119,7 +119,7 @@ func compileFuncDecl(ctx *blockCtx, fn *ast.FuncDecl) {
 			if testMain {
 				entry = "TestMain"
 				testing := pkg.Import("testing")
-				t = pkg.NewParam(token.NoPos, "t", types.NewPointer(testing.Ref("T").Type()))
+				t = pkg.NewParam(token.NoPos, "t", types.NewPointer(testing.Ref("T").Type()), false)
 				entryParams = types.NewTuple(t)
 			}
 			pkg.NewFunc(nil, entry, entryParams, nil, false).BodyStart(pkg)

--- a/cl/internal/convert/package.go
+++ b/cl/internal/convert/package.go
@@ -134,7 +134,7 @@ func (p *Package) newReceiver(typ *ast.FuncType) (*types.Var, error) {
 	if err != nil {
 		return nil, fmt.Errorf("newReceiver:failed to convert type: %w", err)
 	}
-	return p.p.NewParam(token.NoPos, "recv_", recvType), nil
+	return p.p.NewParam(token.NoPos, "recv_", recvType, false), nil
 }
 
 func (p *Package) ToSigSignature(recv *types.Var, funcDecl *ast.FuncDecl) (*types.Signature, error) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/goplus/llcppg
 go 1.23.0
 
 require (
-	github.com/goplus/gogen v1.21.2
+	github.com/goplus/gogen v1.23.3
 	github.com/goplus/lib v0.3.1
 	github.com/goplus/llgo v0.13.0
 	github.com/qiniu/x v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/goplus/gogen v1.21.2 h1:xbXPgZOZiQx/WBM0nZxVSxFbtdCMZCRB+lguDnh8pfs=
-github.com/goplus/gogen v1.21.2/go.mod h1:Y7ulYW3wonQ3d9er00b0uGFEV/IUZa6okWJZh892ACQ=
+github.com/goplus/gogen v1.23.3 h1:cyw16r8LYsqIeJUobTy/1mv9abUDxsR+ghh0dEZgaRw=
+github.com/goplus/gogen v1.23.3/go.mod h1:Y7ulYW3wonQ3d9er00b0uGFEV/IUZa6okWJZh892ACQ=
 github.com/goplus/lib v0.3.1 h1:Xws4DBVvgOMu58awqB972wtvTacDbk3nqcbHjdx9KSg=
 github.com/goplus/lib v0.3.1/go.mod h1:SgJv3oPqLLHCu0gcL46ejOP3x7/2ry2Jtxu7ta32kp0=
 github.com/goplus/llgo v0.13.0 h1:FYT9fe6IuYTXuDRPF/v8VFGeL61cVSrwITxDqEahKiw=

--- a/internal/gowrite/gowrite_test.go
+++ b/internal/gowrite/gowrite_test.go
@@ -37,7 +37,7 @@ func InitHooks() {
 
 func TestWriteTo_NonEmptyFuncStaysMultiline(t *testing.T) {
 	pkg := gogen.NewPackage("", "demo", nil)
-	results := types.NewTuple(pkg.NewParam(token.NoPos, "", types.Typ[types.Int]))
+	results := types.NewTuple(pkg.NewParam(token.NoPos, "", types.Typ[types.Int], false))
 	pkg.NewFunc(nil, "RetZero", nil, results, false).BodyStart(pkg).Val(0).Return(1).End()
 
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary
- bump github.com/goplus/gogen from v1.21.2 to v1.23.3
- update Package.NewParam call sites for the new optional-parameter flag

Supersedes #685.

## Tests
- go test ./cl ./cl/internal/convert ./internal/gowrite

Note: local go test ./... is blocked by untracked local temp files under cmd/gogensig/temp and a missing /opt/homebrew/opt/llvm@18/lib/libclang.dylib for parser tests.